### PR TITLE
chore(flake/home-manager): `a1fddf09` -> `e1391fb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718530513,
-        "narHash": "sha256-BmO8d0r+BVlwWtMLQEYnwmngqdXIuyFzMwvmTcLMee8=",
+        "lastModified": 1720042825,
+        "narHash": "sha256-A0vrUB6x82/jvf17qPCpxaM+ulJnD8YZwH9Ci0BsAzE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a1fddf0967c33754271761d91a3d921772b30d0e",
+        "rev": "e1391fb22e18a36f57e6999c7a9f966dc80ac073",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`e1391fb2`](https://github.com/nix-community/home-manager/commit/e1391fb22e18a36f57e6999c7a9f966dc80ac073) | `` hyprland: onChange: remove subshell comment ``                 |
| [`c05d7204`](https://github.com/nix-community/home-manager/commit/c05d7204a9a27f8fb5d14e1781c108cc851ac14a) | `` hyprland: onChange: check XDG_RUNTIME_DIR as well ``           |
| [`391ca6e9`](https://github.com/nix-community/home-manager/commit/391ca6e950c2525b4f853cbe29922452c14eda82) | `` ci: bump DeterminateSystems/update-flake-lock from 22 to 23 `` |