### PR TITLE
chore(flake/nixpkgs): `89c49874` -> `706eef54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1719426051,
-        "narHash": "sha256-yJL9VYQhaRM7xs0M867ZFxwaONB9T2Q4LnGo1WovuR4=",
+        "lastModified": 1719956923,
+        "narHash": "sha256-nNJHJ9kfPdzYsCOlHOnbiiyKjZUW5sWbwx3cakg3/C4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "89c49874fb15f4124bf71ca5f42a04f2ee5825fd",
+        "rev": "706eef542dec88cc0ed25b9075d3037564b2d164",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                               |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| [`772092fd`](https://github.com/NixOS/nixpkgs/commit/772092fd5046bffc783562d5dc425c7e992e00ce) | `` _389-ds-base: apply patches for CVE-2024-2199 and CVE-2024-3657 ``                                 |
| [`2d8170b0`](https://github.com/NixOS/nixpkgs/commit/2d8170b0a52e8b8b8fd11e3a26a09cb226effaa6) | `` organicmaps: enable wayland support ``                                                             |
| [`7b254600`](https://github.com/NixOS/nixpkgs/commit/7b254600a3121d0845b6b3b40816a7e5c2e7143d) | `` ladybird: enable wayland support ``                                                                |
| [`6b1e9a04`](https://github.com/NixOS/nixpkgs/commit/6b1e9a044fb5d9b0f1380655c30618d814cea352) | `` python3Packages.deltalake: init at 0.18.1 ``                                                       |
| [`eb735207`](https://github.com/NixOS/nixpkgs/commit/eb735207d9ec9c57be35d96ca13bb9fc5bc69c81) | `` maintainers: add andershus ``                                                                      |
| [`3ab293c5`](https://github.com/NixOS/nixpkgs/commit/3ab293c515b77814373ddb3c6fea0f192a1ed3da) | `` ladybird: mark as broken on darwin ``                                                              |
| [`0d1f1b5f`](https://github.com/NixOS/nixpkgs/commit/0d1f1b5fad1fe4016dd64f0a6652cd461b4def62) | `` ladybird: 0-unstable-2024-06-04 -> 0-unstable-2024-06-08 ``                                        |
| [`f9c6ebd8`](https://github.com/NixOS/nixpkgs/commit/f9c6ebd8f59e1da7adef8a2cb089cf042a989139) | `` {mullvad,tor}-browser: Add mimeTypes ``                                                            |
| [`c9bcc7af`](https://github.com/NixOS/nixpkgs/commit/c9bcc7afd69422f9d385a3d16c7bb4f37ba73e5b) | `` lxc: 6.0.0 -> 6.0.1 ``                                                                             |
| [`982b4a1a`](https://github.com/NixOS/nixpkgs/commit/982b4a1a2a957b8eb6ff0b8a4119fab9e0fec17d) | `` yt-dlp: relax requests constraint ``                                                               |
| [`946c8531`](https://github.com/NixOS/nixpkgs/commit/946c85318012b41f74d8091a4c97124a2de7c04a) | `` java-language-server: use headless jdk to reduce dependencies ``                                   |
| [`05bf0573`](https://github.com/NixOS/nixpkgs/commit/05bf0573f2d184757e238f1df7dcbdf8c3b39974) | `` ovn: fix ovn trying to create socket in nix store ``                                               |
| [`c133b51c`](https://github.com/NixOS/nixpkgs/commit/c133b51c7c02588586614de883ce2fe149404663) | `` signal-desktop-beta: 7.14.0-beta.1 -> 7.15.0-beta.1 ``                                             |
| [`63bbb450`](https://github.com/NixOS/nixpkgs/commit/63bbb4508bb0e0e54afda943f14f8618aaab40f2) | `` poppler: apply patch for CVE-2024-6239 ``                                                          |
| [`1123f4e8`](https://github.com/NixOS/nixpkgs/commit/1123f4e8d4b438a18353b2a1c18ea2055efb0793) | `` python311Packages.yt-dlp-light: 2024.5.27 -> 2024.7.1 ``                                           |
| [`ce05c27a`](https://github.com/NixOS/nixpkgs/commit/ce05c27abc168116ceaea76bcde976528375cb64) | `` Revert "[Backport release 24.05] nixos/snapper: add snapper opts" ``                               |
| [`420da033`](https://github.com/NixOS/nixpkgs/commit/420da033d9752263f295fe336a985be189f6469f) | `` lxcfs: 6.0.0 -> 6.0.1 ``                                                                           |
| [`25e969a7`](https://github.com/NixOS/nixpkgs/commit/25e969a78335fc98dcbafd0a18c6bae4fb01f60d) | `` brave: 1.67.116 -> 1.67.123 ``                                                                     |
| [`376288f3`](https://github.com/NixOS/nixpkgs/commit/376288f33d2a5d825c641fc290bbc5da9bc1be48) | `` arc-browser: fix darwin bundle ``                                                                  |
| [`868f9f2d`](https://github.com/NixOS/nixpkgs/commit/868f9f2d13ed90e9171119eccb43921a5dc7d7e8) | `` nss_latest: 3.101 -> 3.101.1 ``                                                                    |
| [`57f2be3e`](https://github.com/NixOS/nixpkgs/commit/57f2be3e455133435799a93e02927caec4030694) | `` maintainers: update mguentner's contact info ``                                                    |
| [`5d2887e1`](https://github.com/NixOS/nixpkgs/commit/5d2887e1a4a9f320542813839b5e43957bb268b5) | `` stats: 2.10.18 -> 2.10.19 ``                                                                       |
| [`db47e669`](https://github.com/NixOS/nixpkgs/commit/db47e669c3e0638e5b921d96f80223f94ef9bac9) | `` envoy: 1.30.3 -> 1.30.4 ``                                                                         |
| [`578c3742`](https://github.com/NixOS/nixpkgs/commit/578c374256c27abc32a782b17146e11dc26939a6) | `` openssh_{hpn,gssapi}: add backported security fix patches ``                                       |
| [`906d42ad`](https://github.com/NixOS/nixpkgs/commit/906d42ad9916d08b8ceb7248417dcae6d557738b) | `` envoy: 1.30.2 -> 1.30.3 ``                                                                         |
| [`047a4e29`](https://github.com/NixOS/nixpkgs/commit/047a4e292b580e1912026a6a6c21e5c1cf21382c) | `` spotify: 1.2.38.720.ga4a70a0e -> 1.2.40.599.g606b7f29 ``                                           |
| [`8000afcf`](https://github.com/NixOS/nixpkgs/commit/8000afcfb389ede3e4712cdf8a5dd4470e56b46d) | `` spotify: 1.2.17.834.g26ee1129 -> 1.2.38.720.ga4a70a0e ``                                           |
| [`10c832d0`](https://github.com/NixOS/nixpkgs/commit/10c832d0548e9e3a6df7eb51e68c2783212a303e) | `` openssh: add backported security fix patches ``                                                    |
| [`762ffe16`](https://github.com/NixOS/nixpkgs/commit/762ffe16710e1e96d3f95d4e6b45a6bed76a5c06) | `` raycast: 1.77.1 -> 1.77.3 ``                                                                       |
| [`f1f02ddc`](https://github.com/NixOS/nixpkgs/commit/f1f02ddc88b4b292e2e99104f7a0e3eff2d702bc) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.21.3 -> 0.22.0 ``                                 |
| [`1e62a530`](https://github.com/NixOS/nixpkgs/commit/1e62a53090dfd1f783b4ec73ff89383bf3fbec7c) | `` linux_xanmod_latest: 6.9.4 -> 6.9.7 ``                                                             |
| [`098926ba`](https://github.com/NixOS/nixpkgs/commit/098926ba268d5bb1eab71cfcb2d775a3781e0bf7) | `` linux_xanmod: 6.6.33 -> 6.6.36 ``                                                                  |
| [`bff4a7e9`](https://github.com/NixOS/nixpkgs/commit/bff4a7e9d04b03739f3fa26995fcfeaa4f092799) | `` nixos/smartd: add systembus-notify notifications ``                                                |
| [`e41d35a1`](https://github.com/NixOS/nixpkgs/commit/e41d35a14452939ebc1dddec28726e8ef5b27477) | `` mysql80: 8.0.36 -> 8.0.37 ``                                                                       |
| [`590d9474`](https://github.com/NixOS/nixpkgs/commit/590d9474b68d90bcd9a46a661ea76529ca18bd3f) | `` arc-browser: 1.48.2-51225 -> 1.49.0-51346 ``                                                       |
| [`f033f9e6`](https://github.com/NixOS/nixpkgs/commit/f033f9e64e8fc37751313bdd0935ba4ddaa13ca8) | `` python3Packages.pdoc: 14.5.0 -> 14.5.1 ``                                                          |
| [`77d07181`](https://github.com/NixOS/nixpkgs/commit/77d07181c140dff1b1fc194f80678d0dcaeea303) | `` docker_27: init at 27.0.2 ``                                                                       |
| [`add428ee`](https://github.com/NixOS/nixpkgs/commit/add428eea7e2c278ddd4b2dc2e1eb5b93f604c33) | `` openssl: Fix build on OpenBSD ``                                                                   |
| [`cee79b77`](https://github.com/NixOS/nixpkgs/commit/cee79b773a187664f03a8fa76ee33bc51457ac19) | `` bash: Fix OpenBSD build ``                                                                         |
| [`846bbb53`](https://github.com/NixOS/nixpkgs/commit/846bbb537a5e8c19e894ee5526a4f7e8f020c1f7) | `` microsoft-edge: 125.0.2535.92 -> 126.0.2592.68 ``                                                  |
| [`6ae5f326`](https://github.com/NixOS/nixpkgs/commit/6ae5f326155a6b500f5ae492d1c3c51275ab7a9e) | `` ntpd-rs: 1.1.2 -> 1.1.3 ``                                                                         |
| [`2412edab`](https://github.com/NixOS/nixpkgs/commit/2412edabe3079145fd3018e1547625dfcd53ee4d) | `` signal-desktop: 7.13.0 -> 7.14.0 ``                                                                |
| [`a3aedcce`](https://github.com/NixOS/nixpkgs/commit/a3aedcce8268bbbb9503ca1804c363b278eb7a97) | `` google-chrome: 126.0.6478.114 -> 126.0.6478.126 ``                                                 |
| [`14ff8701`](https://github.com/NixOS/nixpkgs/commit/14ff870129239fe617c55b4114b8d58ebf74472f) | `` microsoft-edge: 125.0.2535.85 -> 125.0.2535.92 ``                                                  |
| [`48a4c8ce`](https://github.com/NixOS/nixpkgs/commit/48a4c8cec1e46118a830ba071754b607cb17eeaa) | `` chromium-codecs-ffmpeg-extra: 114023 -> 115541 ``                                                  |
| [`1e85f84d`](https://github.com/NixOS/nixpkgs/commit/1e85f84d7b6ace043bd5f6a87ad99bb030baba05) | `` vivaldi: 6.7.3329.41 -> 6.8.3381.46 ``                                                             |
| [`b05cbc84`](https://github.com/NixOS/nixpkgs/commit/b05cbc841f350c2a09b1e775e1adf7d82cfbace1) | `` tests/lomiri: Don't need to keep Morph in the background anymore, content-hub can launch it now `` |
| [`13458513`](https://github.com/NixOS/nixpkgs/commit/13458513c33b16ec9490c54e10419516389a12eb) | `` libsForQt5.qtsystems: Fetch patch to fix crash on XOpenDisplay failure ``                          |
| [`af726777`](https://github.com/NixOS/nixpkgs/commit/af726777eb1308108d0779a19e99f39bf4aab60f) | `` flyctl: fix cross compilation ``                                                                   |
| [`1e53dcb0`](https://github.com/NixOS/nixpkgs/commit/1e53dcb0e172e1880bf90e5ea5a67a0ca2c73424) | `` matrix-sliding-sync: 0.99.18 -> 0.99.19 ``                                                         |
| [`0e13c1bc`](https://github.com/NixOS/nixpkgs/commit/0e13c1bc52f90155ab05b81ce805dfa19aac4bb3) | `` sc-controller: 0.4.8.13 -> 0.4.8.17 ``                                                             |
| [`9e8e29d0`](https://github.com/NixOS/nixpkgs/commit/9e8e29d074a017dc860c51a4ee79acd0787a2d46) | `` matrix-sliding-sync: 0.99.17 -> 0.99.18 ``                                                         |
| [`b8639cd5`](https://github.com/NixOS/nixpkgs/commit/b8639cd5e905267d45d958dde9efe1b68c64284b) | `` qutebrowser: 3.2.0 -> 3.2.1 ``                                                                     |
| [`3057392c`](https://github.com/NixOS/nixpkgs/commit/3057392c6882c0ce5b3ced1bc47ae4e6a53b3586) | `` openbsd.libc: Create from constituent pkgs not hack ``                                             |
| [`a46f39d0`](https://github.com/NixOS/nixpkgs/commit/a46f39d08f73f6b73cfd2b0da919f8e109e5cd5d) | `` openbsd: Remove `STRIP` hack ``                                                                    |
| [`e028de9d`](https://github.com/NixOS/nixpkgs/commit/e028de9dacc0fb2acb0e17a78a4782d624bb2d82) | `` bsdSetupHook: Do not define empty `DESTDIR` ``                                                     |
| [`71db2c94`](https://github.com/NixOS/nixpkgs/commit/71db2c94d80cef5cc94f043e086dd0759e14f5da) | `` principia: 2024.02.29 -> 2024.06.28 ``                                                             |
| [`98442699`](https://github.com/NixOS/nixpkgs/commit/98442699a0ff85a8a74bf3f066f7f6ac3c8aad9b) | `` netbsd.libcMinimal: Cut down on deps, don't build tags ``                                          |
| [`d0740b0c`](https://github.com/NixOS/nixpkgs/commit/d0740b0c8528a2f2cdf9cbcd8712a51fee83db5e) | `` osinfo-db: 20231215 -> 20240510 ``                                                                 |
| [`f70001bf`](https://github.com/NixOS/nixpkgs/commit/f70001bf2db0d2f8b8072282685a0df2f5660ed7) | `` cpython: fix changelog anchor for beta versions ``                                                 |
| [`f1c60fdd`](https://github.com/NixOS/nixpkgs/commit/f1c60fddc84dcedc80d04190dafbb2dc7b179abd) | `` python313: 3.13.0b2 -> 3.13.0b3 ``                                                                 |
| [`65261436`](https://github.com/NixOS/nixpkgs/commit/6526143670da54f4c141a3da65b97684d14a2416) | `` libndp: apply patch for CVE-2024-5564 ``                                                           |
| [`918656f3`](https://github.com/NixOS/nixpkgs/commit/918656f33173b900122e5dd0bbeaa3df590da4cc) | `` linuxKernel.kernels.linux_lqx: 6.9.5-lqx1 -> 6.9.7-lqx1 ``                                         |
| [`a1751e13`](https://github.com/NixOS/nixpkgs/commit/a1751e13c2c7951c8311b0e84d3a253e32cd71c3) | `` linuxKernel.kernels.linux_zen: 6.9.6-zen1 -> 6.9.7-zen1 ``                                         |
| [`7de667dc`](https://github.com/NixOS/nixpkgs/commit/7de667dc8a4554cfaea0fbdf4869cee111637805) | `` nixos/limesurvey: drop default encryption key and nonce ``                                         |
| [`8216b6aa`](https://github.com/NixOS/nixpkgs/commit/8216b6aae27b918a2b66b49d4b4308cfd414faad) | `` vscode-extensions.danielsanmedium.dscodegpt: init at 3.4.10 ``                                     |
| [`2b6debb3`](https://github.com/NixOS/nixpkgs/commit/2b6debb360660186a655565c02021ad53c77b89f) | `` nodejs_18: 18.20.2 -> 18.20.3 (#323118) ``                                                         |
| [`dab5b02d`](https://github.com/NixOS/nixpkgs/commit/dab5b02d57bdc73a40d693ddcd97bc9c74d7cee5) | `` Discord updates ``                                                                                 |
| [`514e8b41`](https://github.com/NixOS/nixpkgs/commit/514e8b41bca649be1394a5807fde8ae5b6eadcd8) | `` discord-canary: 0.0.422 -> 0.0.431 ``                                                              |
| [`1b287bad`](https://github.com/NixOS/nixpkgs/commit/1b287baddae219158beb4dc2d35f2b8dfc3feba5) | `` warp-terminal: 0.2024.06.18.08.02.stable_04 -> 0.2024.06.25.08.02.stable_01 ``                     |
| [`74cb04af`](https://github.com/NixOS/nixpkgs/commit/74cb04af2eb6f57bb9efac1ac439271157b80ac5) | `` wasm-tools: 1.211.1 -> 1.212.0 ``                                                                  |
| [`236282d1`](https://github.com/NixOS/nixpkgs/commit/236282d18a1f31161a0dfb8fb6520b69f3d48eb8) | `` job-security: unstable-0-2024-03-24 -> 0-unstable-2024-04-07 ``                                    |
| [`5146a340`](https://github.com/NixOS/nixpkgs/commit/5146a340c9dc3ae5dcc400546138ccad466495ee) | `` glasskube: 0.2.1 -> 0.11.0 ``                                                                      |
| [`dc0269c6`](https://github.com/NixOS/nixpkgs/commit/dc0269c6c4cc85c118f49a0da04558b036b3095d) | `` toml11: Support windows ``                                                                         |
| [`2504cd30`](https://github.com/NixOS/nixpkgs/commit/2504cd307496949ef88f40fadfd7369381fc8ddf) | `` xivlauncher: regenerate deps.nix ``                                                                |
| [`bd371366`](https://github.com/NixOS/nixpkgs/commit/bd371366778655e0aa5c846f839987a16e2c03cc) | `` xivlauncher: 1.0.8 -> 1.0.9 ``                                                                     |
| [`18e73cad`](https://github.com/NixOS/nixpkgs/commit/18e73cad18d2ccfa9dfd2a9ac6c370a76aa5d751) | `` opera: 110.0.5130.23 -> 110.0.5130.49 ``                                                           |
| [`f09203cf`](https://github.com/NixOS/nixpkgs/commit/f09203cf9cd7050bdc373f6a09ee06c6926cacaf) | `` netbird: 0.27.10 -> 0.28.3 ``                                                                      |
| [`d96f9b6b`](https://github.com/NixOS/nixpkgs/commit/d96f9b6bdc3377ed52cad28dfd00c5f45513a1ee) | `` Resolve _all_ Windows DLL dependencies ``                                                          |
| [`1ea8a373`](https://github.com/NixOS/nixpkgs/commit/1ea8a37379072ef739d1152ada693488dbaf971a) | `` toml11: Support windows ``                                                                         |
| [`f27c665c`](https://github.com/NixOS/nixpkgs/commit/f27c665c67a1c08e0da061be8e1d65117f841d32) | `` nixVersions.git: 2.23.0 -> 2.23.1 (hashes) ``                                                      |
| [`c03d3ce3`](https://github.com/NixOS/nixpkgs/commit/c03d3ce3c7afa63662300386770cd68a21366031) | `` nixVersions: bump patch releases ``                                                                |
| [`ffb2aff4`](https://github.com/NixOS/nixpkgs/commit/ffb2aff40d4bc33e2aecf3ffc9e1c9c46479c5ad) | `` gitlab: 16.11.4 -> 16.11.5 ``                                                                      |
| [`28ba7f38`](https://github.com/NixOS/nixpkgs/commit/28ba7f385d2ce9e0c40306bd5aded10f4a25f4a1) | `` jellyfin-web: 10.9.6 -> 10.9.7 ``                                                                  |
| [`fb030c6f`](https://github.com/NixOS/nixpkgs/commit/fb030c6fb3e211d7c9c28261d2e0e003077f06a7) | `` jellyfin: 10.9.6 -> 10.9.7 ``                                                                      |
| [`a25f62d3`](https://github.com/NixOS/nixpkgs/commit/a25f62d3df8be60e9c5cf2901564108c3e3ff76c) | `` nanopb: 0.4.6 -> 0.4.8 ``                                                                          |
| [`efa938da`](https://github.com/NixOS/nixpkgs/commit/efa938dacc15396d78b41bcbb91b1a19d73bb7e3) | `` maintainers: add liarokapisv ``                                                                    |
| [`a5cb7f7f`](https://github.com/NixOS/nixpkgs/commit/a5cb7f7f3acb919a0a66e9a8e94d71beead4e20a) | `` nanopb: Fix self-inclusive src ``                                                                  |
| [`310d247a`](https://github.com/NixOS/nixpkgs/commit/310d247a8db456902343d0a5e445ce645f9d99a6) | `` flyctl: 0.2.72 -> 0.2.75 ``                                                                        |
| [`a1c754d6`](https://github.com/NixOS/nixpkgs/commit/a1c754d6910966e33ecdbfa7d4d8d526f3c492c0) | `` sc-im: fix build on Darwin ``                                                                      |
| [`045a9671`](https://github.com/NixOS/nixpkgs/commit/045a9671f263c530df8c84537deccede6c3385ba) | `` linux-rt_6_6: 6.6.34-rt33 -> 6.6.35-rt34 ``                                                        |
| [`a429961e`](https://github.com/NixOS/nixpkgs/commit/a429961e53816908366f59d9661917562257a4fd) | `` linux-rt_6_1: 6.1.94-rt33 -> 6.1.95-rt34 ``                                                        |
| [`9ce62b87`](https://github.com/NixOS/nixpkgs/commit/9ce62b87f2a2bbc173af5c97c1766d6666f46571) | `` linux_6_1: 6.1.95 -> 6.1.96 ``                                                                     |
| [`e8ce5e7d`](https://github.com/NixOS/nixpkgs/commit/e8ce5e7df3f7cee840f18f0647273ec71c8ee0d3) | `` linux_6_6: 6.6.35 -> 6.6.36 ``                                                                     |
| [`0f5ad3c3`](https://github.com/NixOS/nixpkgs/commit/0f5ad3c35f8de9e8dbd07cca6dd7e204acf531ad) | `` linux_6_9: 6.9.6 -> 6.9.7 ``                                                                       |
| [`4c3b4c16`](https://github.com/NixOS/nixpkgs/commit/4c3b4c1671f7a98b720e3b2f15c1cee6dcf60ef8) | `` linux_testing: 6.10-rc4 -> 6.10-rc5 ``                                                             |
| [`17abaa6d`](https://github.com/NixOS/nixpkgs/commit/17abaa6dd4f152caf127efbb7b363f1498d69cad) | `` linux-rt_5_15: 5.15.158-rt76 -> 5.15.160-rt77 ``                                                   |
| [`323c3e0b`](https://github.com/NixOS/nixpkgs/commit/323c3e0b8ebb631d090a6680ed1076516b7fb2d1) | `` linux_testing: 6.10-rc3 -> 6.10-rc4 ``                                                             |
| [`dd18a6e7`](https://github.com/NixOS/nixpkgs/commit/dd18a6e7ca0936c333c0637cc6ca713e4368f123) | `` python3Packages.xformers: fix building with cudaSupport ``                                         |
| [`fccfa8b7`](https://github.com/NixOS/nixpkgs/commit/fccfa8b7b8d7008926cd8d86b952f32df6bd20de) | `` linux_testing: 6.10-rc2 -> 6.10-rc3 ``                                                             |
| [`93b59142`](https://github.com/NixOS/nixpkgs/commit/93b59142fa902e4a0831b82ee4a4ada726c91726) | `` linux_testing: 6.10-rc1 -> 6.10-rc2 ``                                                             |
| [`49616114`](https://github.com/NixOS/nixpkgs/commit/49616114950808a3fed6567442c0ede324a20331) | `` qt6.qtmqtt: 6.7.1 -> 6.7.2 ``                                                                      |
| [`fafac49d`](https://github.com/NixOS/nixpkgs/commit/fafac49db5f79990d70990e590eafe7bd9b974bc) | `` qt6: 6.7.1 -> 6.7.2 ``                                                                             |
| [`e76db360`](https://github.com/NixOS/nixpkgs/commit/e76db360de6bdcb9c097fe6c3c26562313e1b217) | `` cargo-tally: 1.0.46 -> 1.0.47 ``                                                                   |
| [`24c21fac`](https://github.com/NixOS/nixpkgs/commit/24c21fac40c496ef1156a8247675402f20ce246c) | `` coqPackages.coq-hammer: init at 1.3.2 ``                                                           |
| [`bef51dc9`](https://github.com/NixOS/nixpkgs/commit/bef51dc92b1739d2cc73b917f4de199697902464) | `` coqPackages.coq-hammer-tactics: init at 1.3.2 ``                                                   |
| [`781632a4`](https://github.com/NixOS/nixpkgs/commit/781632a40c5bf62551fb334e9e770e715d4a75be) | `` ares: fix missing vulkan ``                                                                        |
| [`89ad925e`](https://github.com/NixOS/nixpkgs/commit/89ad925e0530e93d235cbd3bcef5c8cad18745a6) | `` pandoc: apply patch removing the usage of polyfill.io in the templates ``                          |
| [`335a2cfd`](https://github.com/NixOS/nixpkgs/commit/335a2cfd1e43ec75f4a92cb2104d7b6da7ad8e7c) | `` emacs.pkgs.org: stop applying a patch if not needed ``                                             |
| [`b0479552`](https://github.com/NixOS/nixpkgs/commit/b0479552ba933da3036ae87d2b2928595fa1e721) | `` knot-dns: 3.3.6 -> 3.3.7 ``                                                                        |
| [`9c4e8541`](https://github.com/NixOS/nixpkgs/commit/9c4e85410077eed6ea6ca21ef0e2d9f7bc08d2b5) | `` mullvad: 2024.1 -> 2024.3 ``                                                                       |
| [`5a96fcc7`](https://github.com/NixOS/nixpkgs/commit/5a96fcc73d8ac948c6cde5d76ffcdde9ccbf53a2) | `` step-ca: 0.26.1 -> 0.26.2 ``                                                                       |
| [`1171b70c`](https://github.com/NixOS/nixpkgs/commit/1171b70c292a6c3c84412bb4b9f720d80d1b9e31) | `` ungoogled-chromium: 126.0.6478.114-1 -> 126.0.6478.126-1 ``                                        |
| [`740768f1`](https://github.com/NixOS/nixpkgs/commit/740768f1cfc4d5476d96da5b843850c8af012109) | `` networkmanager-openvpn: move to finalAttrs, add homepage ``                                        |
| [`783cebe2`](https://github.com/NixOS/nixpkgs/commit/783cebe2a8db7b6ca107901bf61b42bc9fa2fa93) | `` networkmanager-openvpn: 1.10.2 -> 1.12.0 ``                                                        |
| [`234425f8`](https://github.com/NixOS/nixpkgs/commit/234425f832e7e41e030aca237a188c8c34b23a11) | `` gnome.gnome-sudoku: 46.1 -> 46.2 ``                                                                |
| [`58565c90`](https://github.com/NixOS/nixpkgs/commit/58565c90f4979f422ae79b1694d504b3ebeae304) | `` networkmanager: 1.46.0 -> 1.46.2 ``                                                                |
| [`36cadeba`](https://github.com/NixOS/nixpkgs/commit/36cadeba66136c636d2c4ba20118defe97962e8e) | `` grafana: 10.4.4 -> 10.4.5 ``                                                                       |
| [`2fc78cf1`](https://github.com/NixOS/nixpkgs/commit/2fc78cf1461382cee8dc3f16d73ce56d5752a8c6) | `` nextcloud27Packages: update ``                                                                     |
| [`01fb487f`](https://github.com/NixOS/nixpkgs/commit/01fb487f76773614254381d8bc0576c8051b4044) | `` nextcloud27: 27.1.10 -> 27.1.11 ``                                                                 |
| [`bb8f995a`](https://github.com/NixOS/nixpkgs/commit/bb8f995a222a50d9ce5477c30a08d335157c9441) | `` nextcloud29Packages: update ``                                                                     |
| [`4eb92c5a`](https://github.com/NixOS/nixpkgs/commit/4eb92c5aaca59c6429ff534ff4f2df8420521fef) | `` nextcloud28Packages: update ``                                                                     |
| [`1f721dc5`](https://github.com/NixOS/nixpkgs/commit/1f721dc55ff03b8d3308b8abde02e2b4e557d4cd) | `` nextcloud: 29.0.2 -> 29.0.3 ``                                                                     |
| [`24c0bb8b`](https://github.com/NixOS/nixpkgs/commit/24c0bb8b1f62d2b8a268a9106da9c5a944872f74) | `` nextcloud28: 28.0.6 -> 28.0.7 ``                                                                   |
| [`5e6d2758`](https://github.com/NixOS/nixpkgs/commit/5e6d27584837edd04e696ee15a87073675186500) | `` spotify: 1.2.31.1205.g4d59ad7c -> 1.2.37.701.ge66eb7bc ``                                          |
| [`c902526b`](https://github.com/NixOS/nixpkgs/commit/c902526b898c8aa633dbaa09e4d340a03829aa18) | `` make-disk-image: fix build for systems that use boot.loader.grub.devices ``                        |
| [`82fd6889`](https://github.com/NixOS/nixpkgs/commit/82fd688952f63bb0deeeed0aaf8a0a57b2a7a9c2) | `` thunderbird-unwrapped: 115.12.0 -> 115.12.2 ``                                                     |
| [`59c2386d`](https://github.com/NixOS/nixpkgs/commit/59c2386da960e58399dfd7a37a292b3e5285127d) | `` cargo-temp: 0.2.20 -> 0.2.21 ``                                                                    |
| [`9cc96cf7`](https://github.com/NixOS/nixpkgs/commit/9cc96cf71d81f9b9dc8341b5f27d2ebb89f4b264) | `` cargo-tauri: 1.6.7 -> 1.6.8 ``                                                                     |
| [`07450c73`](https://github.com/NixOS/nixpkgs/commit/07450c73f1a18de2874ed0fda9c9c0a3ec7f336d) | `` cargo-tauri: 1.6.6 -> 1.6.7 ``                                                                     |
| [`f6d0ea9a`](https://github.com/NixOS/nixpkgs/commit/f6d0ea9ae773c9bc6ff02693e09e1653db9e41a6) | `` cargo-shuttle: 0.39.0 -> 0.45.0 ``                                                                 |
| [`6dceb3e2`](https://github.com/NixOS/nixpkgs/commit/6dceb3e2c1ff4c21ed7e7a15322d476a5f413951) | `` cargo-show-asm: 0.2.35 -> 0.2.36 ``                                                                |
| [`6e2dbb77`](https://github.com/NixOS/nixpkgs/commit/6e2dbb773fa1f6a0a586e3101f9c8ce7d9a4ed2d) | `` cargo-semver-checks: 0.31.0 -> 0.32.0 ``                                                           |
| [`8a991b44`](https://github.com/NixOS/nixpkgs/commit/8a991b44232fa4533e3309d611fb0e95b3bcdc9b) | `` cargo-public-api: 0.35.0 -> 0.35.1 ``                                                              |
| [`f20d3b62`](https://github.com/NixOS/nixpkgs/commit/f20d3b62d015bb92ea9d4e1f12247dbdc52d369e) | `` cargo-public-api: 0.34.2 -> 0.35.0 ``                                                              |
| [`9c7cff72`](https://github.com/NixOS/nixpkgs/commit/9c7cff72774da543a570c35688297b32b5142531) | `` cargo-public-api: 0.34.1 -> 0.34.2 ``                                                              |
| [`d6df98b9`](https://github.com/NixOS/nixpkgs/commit/d6df98b9393066464e994a5ceafb8422c212932e) | `` cargo-nextest: 0.9.70 -> 0.9.72 ``                                                                 |
| [`44b91ae7`](https://github.com/NixOS/nixpkgs/commit/44b91ae77ab2b1610260c1d30006ab62bffbf50c) | `` cargo-llvm-cov: 0.6.9 -> 0.6.10 ``                                                                 |
| [`fb592a82`](https://github.com/NixOS/nixpkgs/commit/fb592a8264ce128f26ec7d37d9e97104a5a28efd) | `` cargo-generate: 0.21.0 -> 0.21.1 ``                                                                |
| [`4d259129`](https://github.com/NixOS/nixpkgs/commit/4d25912991dc8a27cb668956c6b4cce912c21304) | `` cargo-dist: 0.15.0 -> 0.16.0 ``                                                                    |
| [`fb09b0ef`](https://github.com/NixOS/nixpkgs/commit/fb09b0efa1a67b6d5cdc658fe469baf83d827b7f) | `` cargo-dist: 0.14.1 -> 0.15.0 ``                                                                    |
| [`102fa198`](https://github.com/NixOS/nixpkgs/commit/102fa19828927cbb604e967129888a77e99a0566) | `` cargo-dist: 0.13.2 -> 0.14.1 ``                                                                    |
| [`826e96e5`](https://github.com/NixOS/nixpkgs/commit/826e96e555cc40a9a582253137dff206d00bfc13) | `` cargo-deny: 0.14.23 -> 0.14.24 ``                                                                  |
| [`23714fe9`](https://github.com/NixOS/nixpkgs/commit/23714fe9e21f23c925d238e9870b8e4d381e8eeb) | `` cargo-deb: 2.2.0 -> 2.3.0 ``                                                                       |
| [`406d3b64`](https://github.com/NixOS/nixpkgs/commit/406d3b64bda8dc4fb9927e486eaa2062aa78cae7) | `` cargo-component: 0.13.1 -> 0.13.2 ``                                                               |
| [`063d530f`](https://github.com/NixOS/nixpkgs/commit/063d530f81b06412ba5333c0e27fad4f2ea23658) | `` cargo-component: 0.13.0 -> 0.13.1 ``                                                               |
| [`a3958c06`](https://github.com/NixOS/nixpkgs/commit/a3958c06cc3f0315a635ac4518a8a944ed9e7a60) | `` cargo-component: 0.12.0 -> 0.13.0 ``                                                               |
| [`a0b1422c`](https://github.com/NixOS/nixpkgs/commit/a0b1422c1480705283e8255214a84a5396b161de) | `` cargo-chef: 0.1.66 -> 0.1.67 ``                                                                    |
| [`c77ce34d`](https://github.com/NixOS/nixpkgs/commit/c77ce34d3d4e3fc5a913f1830c8a828cac83367e) | `` cargo-bolero: 0.9.0 → 0.11.2 ``                                                                    |
| [`ea104a8d`](https://github.com/NixOS/nixpkgs/commit/ea104a8df8a7a24e253abaaf8885307f22a6be23) | `` cargo-binstall: 1.6.8 -> 1.6.9 ``                                                                  |
| [`2b801671`](https://github.com/NixOS/nixpkgs/commit/2b8016715fb8c753f5ac299a9721ef36c0b9195e) | `` cargo-binstall: 1.6.7 -> 1.6.8 ``                                                                  |
| [`f7f5143b`](https://github.com/NixOS/nixpkgs/commit/f7f5143ba1d459566caaf330d19a5c0547ad70cb) | `` cargo-about: 0.6.1 -> 0.6.2 ``                                                                     |
| [`13bbd6c7`](https://github.com/NixOS/nixpkgs/commit/13bbd6c7bcf28d275c9f0397eb19148acc5a7d25) | `` catppuccin-cursors: 0.2.1 -> 0.3.0 ``                                                              |
| [`34aac1e8`](https://github.com/NixOS/nixpkgs/commit/34aac1e8a3d9e03f1ad11ae9ced288d4ed9c0ca4) | `` catppuccin-cursors: 0.2.0 -> 0.2.1 ``                                                              |
| [`ffc864e1`](https://github.com/NixOS/nixpkgs/commit/ffc864e16324a7e95d17d01348c49e217161f310) | `` nixVersions.nix_2_18: 2.18.2 -> 2.18.3 ``                                                          |
| [`22042902`](https://github.com/NixOS/nixpkgs/commit/22042902ab56505c1f8771488f53a16e54021cb4) | `` youtrack: use jdk21 ``                                                                             |
| [`ed3230d2`](https://github.com/NixOS/nixpkgs/commit/ed3230d22b51eadb755917f42f4b2380f2f22804) | `` youtrack: 2024.1.32323 -> 2024.2.34646 ``                                                          |