### PR TITLE
chore(flake/nixpkgs): `706eef54` -> `19484676`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1719956923,
-        "narHash": "sha256-nNJHJ9kfPdzYsCOlHOnbiiyKjZUW5sWbwx3cakg3/C4=",
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "706eef542dec88cc0ed25b9075d3037564b2d164",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`95740a2e`](https://github.com/NixOS/nixpkgs/commit/95740a2e8533783d0fd99655e66c876ecc27a6ae) | `` vscode-extensions.bierner.github-markdown-preview: Init at 0.3.0 ``          |
| [`a9ea4301`](https://github.com/NixOS/nixpkgs/commit/a9ea4301de8e71a1403094c932df86e46a3a3ed3) | `` vscode-extensions.garlicbreadcleric.pandoc-markdown-syntax: Init at 0.0.2 `` |
| [`12efb620`](https://github.com/NixOS/nixpkgs/commit/12efb6202ef2c66ed570a6bfa4dc3192416e555b) | `` vscode-extensions.zaaack.markdown-editor: Init at 0.1.10 ``                  |
| [`752866f3`](https://github.com/NixOS/nixpkgs/commit/752866f39d4af4d2b9a8accf9bb55233d21ed44e) | `` vscode-extensions.ms-vscode-remote.remote-ssh-edit: init at 0.47.2 ``        |
| [`cd490fe2`](https://github.com/NixOS/nixpkgs/commit/cd490fe2cc178ecdf8db6c699d3e99376a1b1266) | `` linux_xanmod_latest: 6.9.7 -> 6.9.8 ``                                       |
| [`ad3c8ac9`](https://github.com/NixOS/nixpkgs/commit/ad3c8ac91e5920fcc41b1e2853060e816800786d) | `` linux_xanmod: 6.6.36 -> 6.6.37 ``                                            |
| [`e01566ac`](https://github.com/NixOS/nixpkgs/commit/e01566ac23ff6d3be89b22986b5fd159f5bbb87a) | `` voms: move to pkgs/by-name ``                                                |
| [`8f090d76`](https://github.com/NixOS/nixpkgs/commit/8f090d768b1f84a1de13b22cea459425eb11dafc) | `` voms: format according to Nix RFC 166 ``                                     |
| [`36da74f2`](https://github.com/NixOS/nixpkgs/commit/36da74f284a667269444892a00d9f079b4644567) | `` turtle: 0.8 -> 0.9 ``                                                        |
| [`51643b4d`](https://github.com/NixOS/nixpkgs/commit/51643b4da6ae47d4c9924e58f535fdef27449dd6) | `` restic: 0.16.4 -> 0.16.5 ``                                                  |
| [`4eeded00`](https://github.com/NixOS/nixpkgs/commit/4eeded0054edc33a5835d4dba2c6b4b76498ac37) | `` tests/lomiri: Add polkit agent test ``                                       |
| [`740a982d`](https://github.com/NixOS/nixpkgs/commit/740a982d6379122ddd11181d9943b80b3c5c94d4) | `` nixos/lomiri: Add polkit agent ``                                            |
| [`c43ae74c`](https://github.com/NixOS/nixpkgs/commit/c43ae74c987d202bc7199305e7d0ddcd5dd18e40) | `` lomiri.lomiri-polkit-agent: init at 0.1 ``                                   |
| [`bdf776d2`](https://github.com/NixOS/nixpkgs/commit/bdf776d2e76643237e45be00b25b632c8bc7f33f) | `` voms: 2.1.0-rc2-unstable-2022-06-14 -> 2.1.0 (#270400) ``                    |
| [`6c9a18b4`](https://github.com/NixOS/nixpkgs/commit/6c9a18b495d77d975c937ce607f4b78d1eb0351d) | `` voms: normalize pname and version ``                                         |
| [`dd1aeb20`](https://github.com/NixOS/nixpkgs/commit/dd1aeb204296894a2cba3c5ce240aefb9344608d) | `` weevely: init at 4.0.2-unstable-2024-04-29 ``                                |
| [`7a748a09`](https://github.com/NixOS/nixpkgs/commit/7a748a090155fa320bf75a471f04b9c8a6575790) | `` clightning: 24.02.2 -> 24.05 ``                                              |
| [`8e0025bb`](https://github.com/NixOS/nixpkgs/commit/8e0025bb17e1650e29ad71082f074b095140d1a7) | `` gnome-clocks: remove unnecessary sound theme ``                              |
| [`69181596`](https://github.com/NixOS/nixpkgs/commit/691815964b2691bd33d6c1dabd355a314dced535) | `` gnome-clocks: add missing gstreamer dependency ``                            |
| [`965fa33d`](https://github.com/NixOS/nixpkgs/commit/965fa33d5909c7f97773959ffd82b67d365fd0c5) | `` gnome-clocks: update description ``                                          |
| [`8424b4f5`](https://github.com/NixOS/nixpkgs/commit/8424b4f51a1c5c0b176c8e9b3b2bed15837bf4f6) | `` gnome-clocks: rec -> finalAttrs, nixfmt-rfc-style ``                         |
| [`163d94a6`](https://github.com/NixOS/nixpkgs/commit/163d94a6aebcac24ce68b7261c3a929658683822) | `` cargo-run-bin: 1.7.2 -> 1.7.3 ``                                             |
| [`06995c52`](https://github.com/NixOS/nixpkgs/commit/06995c52519e2f236401d151f167b4ac5a178d74) | `` exe2hex: init at 1.5.2-unstable-2020-04-27 ``                                |
| [`f0bd0e50`](https://github.com/NixOS/nixpkgs/commit/f0bd0e509315202abd6a87ea62b21f4705b6d203) | `` arc-browser: 1.49.0-51346 -> 1.49.1-51495 ``                                 |
| [`8ca5160b`](https://github.com/NixOS/nixpkgs/commit/8ca5160be8b678a9b5ef1ebdd2c74555e3654d64) | `` CODEOWNERS: remove samueldr ``                                               |
| [`91a6b39a`](https://github.com/NixOS/nixpkgs/commit/91a6b39abb591dfe647e0a23e2db87e0820e464a) | `` azure-cli: add katexochen as maintainer ``                                   |
| [`3e155b82`](https://github.com/NixOS/nixpkgs/commit/3e155b828e152d51a3637912cb5502b6c2761b2b) | `` maintainers: remove jonringer ``                                             |
| [`c908aa4f`](https://github.com/NixOS/nixpkgs/commit/c908aa4ffddd4a1888eb6465bc8fe029f63e8940) | `` treewide: remove jonringer as package maintainer ``                          |
| [`1069b59b`](https://github.com/NixOS/nixpkgs/commit/1069b59b068e5c0b3644f9ab929673333f564b35) | `` maintainers: remove jonringer from all teams ``                              |
| [`2346b3aa`](https://github.com/NixOS/nixpkgs/commit/2346b3aa26c67708670ba07e7d5b7d781c3ed0af) | `` CODEOWNERS: remove jonringer ``                                              |
| [`d9b04d66`](https://github.com/NixOS/nixpkgs/commit/d9b04d666978802a1079e2d1145c4be31dd6dd3a) | `` CODEOWNERS: add corngood to dotnet paths ``                                  |
| [`65b7ebd2`](https://github.com/NixOS/nixpkgs/commit/65b7ebd2c5e2d7a022c8b9e58ecf3f2f693f0bef) | `` maintainers: remove ivar ``                                                  |
| [`1b4443ad`](https://github.com/NixOS/nixpkgs/commit/1b4443ade9ba91b157a2d2b140254830252dd7d4) | `` qq: 3.2.9 -> 3.2.10 ``                                                       |
| [`91745c5b`](https://github.com/NixOS/nixpkgs/commit/91745c5bfd895d7ce671824b0aa37618c0f21c52) | `` linux-rt_6_6: 6.6.35-rt34 -> 6.6.36-rt35 ``                                  |
| [`30e0426f`](https://github.com/NixOS/nixpkgs/commit/30e0426f16cc2fd25aa919db8c18ef40608672af) | `` linux-rt_6_1: 6.1.95-rt34 -> 6.1.96-rt35 ``                                  |
| [`07b66ec2`](https://github.com/NixOS/nixpkgs/commit/07b66ec29ecdfb167ec2116b68b10e08e2b4aa17) | `` linux-rt_5_4: 5.4.271-rt89 -> 5.4.278-rt91 ``                                |
| [`ef37c549`](https://github.com/NixOS/nixpkgs/commit/ef37c549a5c99eb0b2172e9dd9f4e2ab63f0f5dd) | `` linux-rt_5_10: 5.10.218-rt110 -> 5.10.219-rt111 ``                           |
| [`e780bb8b`](https://github.com/NixOS/nixpkgs/commit/e780bb8b4db4585914fc5412c21241dfd840ffa0) | `` linux_4_19: 4.19.316 -> 4.19.317 ``                                          |
| [`99c8a4f3`](https://github.com/NixOS/nixpkgs/commit/99c8a4f307233ea98933f06428a5858b0242f47c) | `` linux_5_4: 5.4.278 -> 5.4.279 ``                                             |
| [`4a177e84`](https://github.com/NixOS/nixpkgs/commit/4a177e84233051908aef064e466a52e4eb402425) | `` linux_5_10: 5.10.220 -> 5.10.221 ``                                          |
| [`1d5bb22e`](https://github.com/NixOS/nixpkgs/commit/1d5bb22e12139fc941f437dda408b69691cc12c3) | `` linux_5_15: 5.15.161 -> 5.15.162 ``                                          |
| [`af7d23bb`](https://github.com/NixOS/nixpkgs/commit/af7d23bb5f9cc58563f2a3d47888f2fcf947ba75) | `` linux_6_1: 6.1.96 -> 6.1.97 ``                                               |
| [`988d2a0a`](https://github.com/NixOS/nixpkgs/commit/988d2a0a65d10f6b0f39a5cb81fc920dc8c638ae) | `` linux_6_6: 6.6.36 -> 6.6.37 ``                                               |
| [`6856e2c6`](https://github.com/NixOS/nixpkgs/commit/6856e2c61c6c1f0da3bfd54f8347e16357dd1bee) | `` linux_6_9: 6.9.7 -> 6.9.8 ``                                                 |
| [`e648d19f`](https://github.com/NixOS/nixpkgs/commit/e648d19f93b510f70d9389988d674c951eb3760c) | `` linux_testing: 6.10-rc5 -> 6.10-rc6 ``                                       |
| [`72eb017b`](https://github.com/NixOS/nixpkgs/commit/72eb017bfb23bf50d43e16553885dec8f6845aa7) | `` raycast: 1.78.0 -> 1.78.1 ``                                                 |
| [`8b531800`](https://github.com/NixOS/nixpkgs/commit/8b531800a90415f846455baa55f2d3cb05e00483) | `` astromenace: add fgaz to maintainers ``                                      |
| [`96167f79`](https://github.com/NixOS/nixpkgs/commit/96167f79c14d4c0f7709917db5b54053aae0aeb6) | `` astromenace: 1.4.1 -> 1.4.2 ``                                               |
| [`2938af84`](https://github.com/NixOS/nixpkgs/commit/2938af84a159faad5af4b9b5bce0214d5ffd1ac5) | `` matrix-appservice-irc: 2.0.0 -> 2.0.1 ``                                     |
| [`30e1d604`](https://github.com/NixOS/nixpkgs/commit/30e1d604c1f5ce712e51db16a44080097a68cb45) | `` matrix-synapse-unwrapped: 1.109.0 -> 1.110.0 ``                              |
| [`5429fca5`](https://github.com/NixOS/nixpkgs/commit/5429fca56467ccec09d2d566629b54ae80fb8168) | `` yanic: 1.5.2 -> 1.6.1 ``                                                     |
| [`f950d8fc`](https://github.com/NixOS/nixpkgs/commit/f950d8fcdff5a20bc4d8c71b04afe9a951b9a7a2) | `` quickemu: fix Samba shares ``                                                |
| [`7aade7bb`](https://github.com/NixOS/nixpkgs/commit/7aade7bb7b6993cac8259987f5356cd31ed1d5e9) | `` quickemu: 4.9.4-unstable-2024-05-28 -> 4.9.5 ``                              |
| [`0b8b5f1c`](https://github.com/NixOS/nixpkgs/commit/0b8b5f1c504b6d133b322ae5f0ce1dbb2aeb4c4e) | `` quickemu: 4.9.4 -> 4.9.4-unstable-2024-05-28 ``                              |
| [`fdc75579`](https://github.com/NixOS/nixpkgs/commit/fdc755798c54752034cd087cd7ee3967df2570a7) | `` quickemu: decrease windows ram requirements ``                               |
| [`d2f6629d`](https://github.com/NixOS/nixpkgs/commit/d2f6629dbbd2860a30e441fd2f90571eaebc8481) | `` quickemu: format with nixfmt-rfc-style ``                                    |
| [`6a83f618`](https://github.com/NixOS/nixpkgs/commit/6a83f618e098d9801543b0ae5c1de018b047b34f) | `` tests/lomiri: Fix OCR detection ``                                           |
| [`f2a40608`](https://github.com/NixOS/nixpkgs/commit/f2a40608e6b55661cac28e473e28b6208da53c01) | `` nixos/gitlab: Add missing state folder ``                                    |
| [`6dd53e25`](https://github.com/NixOS/nixpkgs/commit/6dd53e2532c24214bf2b72ce0fa807e24da2a4eb) | `` nixos/gitlab: Assert PostgreSQL >= 14.9 ``                                   |
| [`768ab07b`](https://github.com/NixOS/nixpkgs/commit/768ab07b10b6a93ef4760457d34ae8a1fc238ded) | `` gitlab: 16.11.5 -> 17.1.1 ``                                                 |
| [`835cf2d3`](https://github.com/NixOS/nixpkgs/commit/835cf2d3f37989c5db6585a28de967a667a75fb1) | `` linux-packages: init at ${linuxHeaders.version} ``                           |
| [`781498fe`](https://github.com/NixOS/nixpkgs/commit/781498fe980c61824c95b5d645240784814882e3) | `` nixos/networkd: add new Network section options ``                           |
| [`219ce470`](https://github.com/NixOS/nixpkgs/commit/219ce470c49a374f73c0f13eeb40ab432d821994) | `` nixos/networkd: allow KeepCarrier in tunConfig and tapConfig ``              |
| [`472a5701`](https://github.com/NixOS/nixpkgs/commit/472a5701414cf7c1f316e07e03232f9358cacf41) | `` git-cola: set meta.mainProgram ``                                            |
| [`fc70d945`](https://github.com/NixOS/nixpkgs/commit/fc70d9455d3f468268eab4cf9a5e838e650db481) | `` gcal: set meta.mainProgram ``                                                |
| [`898c75df`](https://github.com/NixOS/nixpkgs/commit/898c75df005393e94f493ecf1e8cf9327f0f88f3) | `` discourse.plugins.discourse-migratepassword: 1.16.3 -> 1.17.0 ``             |
| [`afbd4aec`](https://github.com/NixOS/nixpkgs/commit/afbd4aecbb9f6dd90b4215a4e6f4461e5699eecb) | `` discourse: 3.2.2 -> 3.2.3 ``                                                 |
| [`9ddbc872`](https://github.com/NixOS/nixpkgs/commit/9ddbc8729197950daf440055765aa1e543abb8b3) | `` discourse: fix update script after nix-universal-prefetch removal ``         |
| [`e8f680e0`](https://github.com/NixOS/nixpkgs/commit/e8f680e000d5c5b4a0ff998e6423951bcf06ba35) | `` mastodon: 4.2.9 -> 4.2.10 ``                                                 |
| [`d8951195`](https://github.com/NixOS/nixpkgs/commit/d8951195fc40e81433831cc14ed6e6f1c5ee2472) | `` forgejo: 7.0.4 -> 7.0.5 ``                                                   |
| [`19b88de2`](https://github.com/NixOS/nixpkgs/commit/19b88de235b1b0bc510cb9c76a55db85c35ef29c) | `` forgejo: remove no longer required patch ``                                  |
| [`77b4d800`](https://github.com/NixOS/nixpkgs/commit/77b4d80083befb635600830c17a38495784e80f9) | `` geoserver: 2.25.1 -> 2.25.2 ``                                               |
| [`271b3a6f`](https://github.com/NixOS/nixpkgs/commit/271b3a6f3f662ef9be6a4fb024ee05b1201d5007) | `` netbird-ui: 0.28.3 -> 0.28.4 ``                                              |
| [`e6eb9ad2`](https://github.com/NixOS/nixpkgs/commit/e6eb9ad249f8c2f43190bb3d66bf9339a73c9146) | `` xprintidle: 0.2.5 -> 0.3.0 ``                                                |
| [`db4b561d`](https://github.com/NixOS/nixpkgs/commit/db4b561d4a9f395c53d95051c9b62e509884859d) | `` sigi: 3.7.0 -> 3.7.1 ``                                                      |
| [`a291727a`](https://github.com/NixOS/nixpkgs/commit/a291727a292eeea32ff60b29f328229d229134b8) | `` znc: update CVE_2024-39844 patch ``                                          |
| [`5fa2abaf`](https://github.com/NixOS/nixpkgs/commit/5fa2abafd592ccda3a7705519b57d75e1da8418a) | `` apacheHttpd: 2.4.59 -> 2.4.61 ``                                             |
| [`e70820b9`](https://github.com/NixOS/nixpkgs/commit/e70820b94bc0c331b8942d18de6f9236b2b64ad1) | `` python3Packages.astropy: apply patch removing the usage of polyfill.io ``    |
| [`d9c3cec2`](https://github.com/NixOS/nixpkgs/commit/d9c3cec2473987184ea21d40ba02f06a5081488c) | `` znc: fix modtcl rce ``                                                       |
| [`46d21a43`](https://github.com/NixOS/nixpkgs/commit/46d21a43d355ba7807b5bd8fbfe849ea234585b8) | `` datadog-agent: fix ``                                                        |
| [`fc82e1d7`](https://github.com/NixOS/nixpkgs/commit/fc82e1d7967ad4ba8d2f4eace9003f625fd0a1b1) | `` raycast: 1.77.3 -> 1.78.0 ``                                                 |
| [`0c03a258`](https://github.com/NixOS/nixpkgs/commit/0c03a2584a3c3aa7a55888bd9be9d4ff61aee1fb) | `` rcu: Fix hash ``                                                             |
| [`c66a270f`](https://github.com/NixOS/nixpkgs/commit/c66a270f0406ed0b064c4d3c91b6459ae41bae57) | `` rcu: 2024.001o -> 2024.001p ``                                               |
| [`6e1adc0e`](https://github.com/NixOS/nixpkgs/commit/6e1adc0ee3590eb861f6e01773404557abf00774) | `` cinnamon.nemo: Backport search window fix ``                                 |
| [`5e391d70`](https://github.com/NixOS/nixpkgs/commit/5e391d70aa7a046fdb5860628fb851484f5df1e0) | `` lxd-unwrapped-lts: 5.21.0 -> 5.21.1 ``                                       |
| [`9817cd40`](https://github.com/NixOS/nixpkgs/commit/9817cd40f185969129defc67a2bda327c45640b8) | `` lxd-unwrapped-lts: fetch from github and fix updater ``                      |
| [`5896582c`](https://github.com/NixOS/nixpkgs/commit/5896582c4bc3f07e19c2bfc28c9343bd78f72f5e) | `` yt-dlp: 2024.7.1 -> 2024.7.2 ``                                              |
| [`70ab1fff`](https://github.com/NixOS/nixpkgs/commit/70ab1fff7b3988ba369b98b75d3610e88945b949) | `` python311Packages.pytorch-metric-learning: refactor ``                       |
| [`ff816960`](https://github.com/NixOS/nixpkgs/commit/ff8169603ef974a74c8f0107e955d536d8d295f2) | `` python311Packages.libknot: 3.3.6 -> 3.3.7 ``                                 |
| [`ab232718`](https://github.com/NixOS/nixpkgs/commit/ab2327188f97c0a3a986b3d6651821eed32b1231) | `` yaml-language-server: drop dev dependencies to reduce closure size ``        |
| [`b0bab788`](https://github.com/NixOS/nixpkgs/commit/b0bab788e1094b73cbef77a834269972dc2af9a3) | `` docker_27: 27.0.2 -> 27.0.3 ``                                               |
| [`1a6886d4`](https://github.com/NixOS/nixpkgs/commit/1a6886d44a41fee312974a364811d7289507b1b3) | `` flyctl: 0.2.75 -> 0.2.79 ``                                                  |
| [`0eb8623b`](https://github.com/NixOS/nixpkgs/commit/0eb8623b7ad5c3e9e2ca58dcc7ead2eb16a58c3b) | `` qq: 3.2.9_240606 -> 3.2.9_240617 ``                                          |
| [`22cfd377`](https://github.com/NixOS/nixpkgs/commit/22cfd37734ae5086511472eb701368f649a6bf3f) | `` maintainers: add Bot-wxt1221 ``                                              |
| [`4cd1ef8c`](https://github.com/NixOS/nixpkgs/commit/4cd1ef8cbfd4d7f0008cd9997f65e7cd7f92befd) | `` sigi: 3.6.4 -> 3.7.0 ``                                                      |
| [`fc61b983`](https://github.com/NixOS/nixpkgs/commit/fc61b983af58d42b155104a623390bb3a7166603) | `` go: 1.21.11 -> 1.21.12 ``                                                    |
| [`77308c4d`](https://github.com/NixOS/nixpkgs/commit/77308c4d65e78eba0288a1af4ab77205b32f277e) | `` opera: 110.0.5130.49 -> 111.0.5168.43 ``                                     |
| [`d97992f9`](https://github.com/NixOS/nixpkgs/commit/d97992f9a74aaf492627158366280ea3cfd2b52f) | `` gscan2pdf: 2.13.2 -> 2.13.3 ``                                               |
| [`04df0e0c`](https://github.com/NixOS/nixpkgs/commit/04df0e0c2f6ccab51673f7a9c36f09896fb4efdc) | `` incus-lts: 6.0.0 -> 6.0.1 ``                                                 |
| [`be27a92e`](https://github.com/NixOS/nixpkgs/commit/be27a92e35a6b8ddcb9272aa1841e7cfdd9beacf) | `` quarto: apply patch removing the usage of polyfill.io in the templates ``    |
| [`de5022c3`](https://github.com/NixOS/nixpkgs/commit/de5022c3089a47179adae11a8a70e794d0ab7f3a) | `` albert: 0.23.0 -> 0.24.1 ``                                                  |
| [`adc86a6c`](https://github.com/NixOS/nixpkgs/commit/adc86a6ce4c77e085552851c59868e8cb5f099b3) | `` albert: format with nixfmt ``                                                |
| [`eb3ff6ac`](https://github.com/NixOS/nixpkgs/commit/eb3ff6ac3b5d1a2e407e6058266616467b7dfa40) | `` albert: add eljamm as maintainer ``                                          |
| [`b2b90850`](https://github.com/NixOS/nixpkgs/commit/b2b90850adb37a56f97142af416530716ace034b) | `` loopwm: init at 1.0.0 ``                                                     |
| [`ef22a54d`](https://github.com/NixOS/nixpkgs/commit/ef22a54d0ec8a8a0fd4db0b8cd2756591305d91f) | `` openpgp-ca: init at 0.13.1 ``                                                |
| [`d6008491`](https://github.com/NixOS/nixpkgs/commit/d600849170d52fbdef482b24ae089e890147ac30) | `` singularity-tools.buildImage: increase default memSize ``                    |
| [`162569e8`](https://github.com/NixOS/nixpkgs/commit/162569e8ac65828ffb1b812797c526f6710566f6) | `` apptainer, singularity: refactor defaultPath substitution ``                 |
| [`a3bcdc9d`](https://github.com/NixOS/nixpkgs/commit/a3bcdc9d87022ccbf216a6bec8fcba091ad1fee8) | `` apptainer, singularity: add mount to defaultPathInputs ``                    |