### PR TITLE
chore(flake/nixpkgs): `19484676` -> `249fbde2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "lastModified": 1720553833,
+        "narHash": "sha256-IXMiHQMtdShDXcBW95ctA+m5Oq2kLxnBt7WlMxvDQXA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "rev": "249fbde2a178a2ea2638b65b9ecebd531b338cf9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`0c3ed0ef`](https://github.com/NixOS/nixpkgs/commit/0c3ed0ef98e447d5b7ed0ab45c1894f416bd53cd) | `` k3s: 1.30.1+k3s1 -> 1.30.2+k3s2 ``                                                   |
| [`f30eb0eb`](https://github.com/NixOS/nixpkgs/commit/f30eb0ebaf3abbc14d01722039cf03be7f4f274a) | `` signal-desktop: 7.14.0 -> 7.15.0 ``                                                  |
| [`aa01c352`](https://github.com/NixOS/nixpkgs/commit/aa01c35210e77675788376845042a5bd19ec8f77) | `` [Backport release-24.05] virtualbox & virtualboxGuestAdditions: cleanup (#318311) `` |
| [`48e4da30`](https://github.com/NixOS/nixpkgs/commit/48e4da30e0362b31ef2f6a62a189b76936f6d537) | `` mopidy-youtube: replace youtube-dl with yt-dlp ``                                    |
| [`ee10d90d`](https://github.com/NixOS/nixpkgs/commit/ee10d90d89e5f2eb02cbea04bafca2100f122ff5) | `` linux-firmware: 20240610 -> 20240709 ``                                              |
| [`2c2203e5`](https://github.com/NixOS/nixpkgs/commit/2c2203e5361c5de66836c194e03f71a38fbb99f3) | `` linux-firmware: remove FOD ``                                                        |
| [`238d5390`](https://github.com/NixOS/nixpkgs/commit/238d53908bae152e33439e55eb00d9add734081e) | `` chatd: init at 1.1.2 ``                                                              |
| [`58f85957`](https://github.com/NixOS/nixpkgs/commit/58f859572d07eaf55b6d216cee031df075bdaa15) | `` nixos/deconz: treat SIGTERM exit status as success ``                                |
| [`e1548041`](https://github.com/NixOS/nixpkgs/commit/e1548041915291ed51bd64a5afb10d48e27d692b) | `` vscode: 1.90.2 -> 1.91.0 ``                                                          |
| [`c968dc9a`](https://github.com/NixOS/nixpkgs/commit/c968dc9ae41bef0e0c3ac8e15e4200a7fd197a87) | `` vscode: 1.90.1 -> 1.90.2 ``                                                          |
| [`7b0e3e2a`](https://github.com/NixOS/nixpkgs/commit/7b0e3e2a259e6c0332f82e18df166faf39fd5124) | `` vscode: 1.90.0 -> 1.90.1 ``                                                          |
| [`b4420b5a`](https://github.com/NixOS/nixpkgs/commit/b4420b5a09e220fd7b8db224a13c0fd504c3e637) | `` vscode: 1.89.1 -> 1.90.0 ``                                                          |
| [`8dae8d6f`](https://github.com/NixOS/nixpkgs/commit/8dae8d6f532e2011b9bd68bd27fde3fa20ac7e7b) | `` keycastr: init at 0.9.18 ``                                                          |
| [`1dd32363`](https://github.com/NixOS/nixpkgs/commit/1dd32363a7b1c66ed5c98aba6e2ec8b77b2dd3a0) | `` lorri: 1.6.0 -> 1.7.0 ``                                                             |
| [`29869211`](https://github.com/NixOS/nixpkgs/commit/298692111ed263d3afe6c9c53c6149e299ec2d1a) | `` (lorri) (update tests) ``                                                            |
| [`94b8ae84`](https://github.com/NixOS/nixpkgs/commit/94b8ae84d649f265c921110f1e5c77751d02b7d6) | `` (lorri): (1.6.0 -> 1.7.0) ``                                                         |
| [`110fd8d5`](https://github.com/NixOS/nixpkgs/commit/110fd8d57734d192f5ea43eb5bc0b41d2004a143) | `` mkCoqDerivation: fix install path of ML plug-in built w/ dune ``                     |
| [`9ffe1340`](https://github.com/NixOS/nixpkgs/commit/9ffe134053da5c9505db749e0279f30f82d494ce) | `` emacs.pkgs.org-xlatex: 20230820 -> 20240707 ``                                       |
| [`8daa2ee1`](https://github.com/NixOS/nixpkgs/commit/8daa2ee1f487158b1f18aa4dbb745240b9a1daa7) | `` microsoft-edge: 126.0.2592.68 -> 126.0.2592.87 ``                                    |
| [`e8cf19dd`](https://github.com/NixOS/nixpkgs/commit/e8cf19dd40873b6618af6a10d316cf3bf852f75d) | `` Move cython to lib-agent's propagatedBuildInputs section ``                          |
| [`204f06e5`](https://github.com/NixOS/nixpkgs/commit/204f06e531357f36bd454897cfcb6a6e3652daaf) | `` Add missing cython dependency ``                                                     |
| [`e818b361`](https://github.com/NixOS/nixpkgs/commit/e818b3612bc8a7234ce9576c28227563413cd3f2) | `` alt-tab-macos: 6.70.1 -> 6.71.0 ``                                                   |
| [`e67f1967`](https://github.com/NixOS/nixpkgs/commit/e67f19672d2aeebd564823d0174f068efc32c37f) | `` nixos/lomiri: Add clock ``                                                           |
| [`6e7550e0`](https://github.com/NixOS/nixpkgs/commit/6e7550e08f2fc65799d2b7f674f9a65f347d3fd8) | `` tests/lomiri-clock-app: init ``                                                      |
| [`20caa24d`](https://github.com/NixOS/nixpkgs/commit/20caa24dc5104764b4377647e68ca8a4804d8613) | `` lomiri.lomiri-clock-app: init at 4.0.3 ``                                            |
| [`9bac7823`](https://github.com/NixOS/nixpkgs/commit/9bac7823effa70d751843a2c4b24e88a8491ed79) | `` github/workflows/check-nix-format: add maintainers files ``                          |
| [`5b12d2c8`](https://github.com/NixOS/nixpkgs/commit/5b12d2c8bbd7fe26c46c8b8d16b9e581f18204f5) | `` maintainers/maintainers-list: format with nixfmt ``                                  |
| [`5c6967e0`](https://github.com/NixOS/nixpkgs/commit/5c6967e0acd06ea4d2ca1909406e07f1637d872e) | `` maintainers/team-list: format with nixfmt ``                                         |
| [`e02f6f1d`](https://github.com/NixOS/nixpkgs/commit/e02f6f1dd3f67af513493bea1a41941f09c2c0c5) | `` youtube-dl: mark as vulnerable ``                                                    |
| [`e4f1101f`](https://github.com/NixOS/nixpkgs/commit/e4f1101fd0de5f1949aaa75e7c6177d3889e3740) | `` julia.withPackages: fix weak deps on Julia 1.10 ``                                   |
| [`1c66ca59`](https://github.com/NixOS/nixpkgs/commit/1c66ca59c9320a1b01e7e033408545573270f7f2) | `` julia.withPackages: bump registry to latest ``                                       |
| [`5ea33034`](https://github.com/NixOS/nixpkgs/commit/5ea330345795ead7738356e421803aaf38c34a4b) | `` julia.withPackages: add a comment about Git usage ``                                 |
| [`e3fef1f8`](https://github.com/NixOS/nixpkgs/commit/e3fef1f87c6cb09fd5669a747d66eba0549c9512) | `` yt-dlp: 2024.7.2 -> 2024.7.7 ``                                                      |
| [`56241d8e`](https://github.com/NixOS/nixpkgs/commit/56241d8e932caa5404e553c272b0afb2a8983106) | `` php83: 8.3.8 -> 8.3.9 ``                                                             |
| [`828d0860`](https://github.com/NixOS/nixpkgs/commit/828d0860af83fd0b41323f84f7aa8d233a0d9965) | `` apacheHttpdPackages.php: 8.2.20 -> 8.2.21 ``                                         |
| [`82cb3ba2`](https://github.com/NixOS/nixpkgs/commit/82cb3ba298690dc7f2a8c112da1f76de61ed9299) | `` paper-plane: add missing gstreamer plugins ``                                        |
| [`89ab8093`](https://github.com/NixOS/nixpkgs/commit/89ab80936110cfd15980fd1994c7f9842d508299) | `` pkcs11-provider: 0.4 -> 0.5 ``                                                       |
| [`d937de50`](https://github.com/NixOS/nixpkgs/commit/d937de505cd3d1d851a4e6c93f44630a16768fa2) | `` mattermost: fix version-regex and support webapp update ``                           |
| [`b8e2496c`](https://github.com/NixOS/nixpkgs/commit/b8e2496c7646f05bb359253fba9fe47c034b7e09) | `` python312Packages.pycrdt: 0.8.24 -> 0.8.31 ``                                        |
| [`5f5ff5dc`](https://github.com/NixOS/nixpkgs/commit/5f5ff5dc4aae7bc226d88433ffe0c1534b6fb4e1) | `` maintainers: update bb010g ``                                                        |
| [`08baeb4b`](https://github.com/NixOS/nixpkgs/commit/08baeb4b3d66bf17a41e9b0c6e4e16d9ee99a4c9) | `` nixos/lomiri: Add calculator ``                                                      |
| [`c23c8976`](https://github.com/NixOS/nixpkgs/commit/c23c8976edf582d1f7fd0468b8260691a9ccef6e) | `` tests/lomiri-calculator-app: init ``                                                 |
| [`584aa0b8`](https://github.com/NixOS/nixpkgs/commit/584aa0b87d6756b960b8703a9c998a0d8c793024) | `` lomiri.lomiri-calculator-app: init at 4.0.2 ``                                       |
| [`afdcd89a`](https://github.com/NixOS/nixpkgs/commit/afdcd89a1a6a519b1d08024711a846542d557a65) | `` python3Packages.nikola: 8.3.0 -> 8.3.1 ``                                            |
| [`cb11c289`](https://github.com/NixOS/nixpkgs/commit/cb11c289af59da3192267e55f4b6ffb1a29fdc67) | `` fairywren: init at 0-unstable-2024-06-10 ``                                          |
| [`b4e003a5`](https://github.com/NixOS/nixpkgs/commit/b4e003a5e2498a5be1f383489fb8479dd3615da5) | `` ansible-cmdb: init at 1.31 ``                                                        |
| [`92ce49ea`](https://github.com/NixOS/nixpkgs/commit/92ce49ea60a317c1ab788ccfc5e179de25e6bf04) | `` python3Packages.jsonxs: init at 0.6 ``                                               |
| [`7536f7bd`](https://github.com/NixOS/nixpkgs/commit/7536f7bd7e3df55b188a7dcb4f058d4c11948b20) | `` authentik,authentik-outposts.ldap: 2024.2.2 -> 2024.2.4 ``                           |
| [`556219d1`](https://github.com/NixOS/nixpkgs/commit/556219d16f5a70231d3fe88c1851e163f441ef6c) | `` vnote: move to pkgs/by-name ``                                                       |
| [`5e2a31c2`](https://github.com/NixOS/nixpkgs/commit/5e2a31c2f67eb37ff87195e9f38b4ed8fa9050b8) | `` vnote: 3.17.0 -> 3.18.0 ``                                                           |
| [`c5897e97`](https://github.com/NixOS/nixpkgs/commit/c5897e972910f271cf2ecc6457ac7c1353773af5) | `` catppuccin-gtk: fix inconsistent theme name ``                                       |