### PR TITLE
chore(flake/nix-ld-rs): `ce02bc08` -> `5b6dc9fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720518322,
-        "narHash": "sha256-isTUoKDWTeDBN1fPuMTyPdYcTn1823LMr+Uy1wODe/0=",
+        "lastModified": 1720768024,
+        "narHash": "sha256-PPLcyhdBrrT0KaQ6B4COIc1TRkO1apyr21i+rc2Ji3Q=",
         "owner": "nix-community",
         "repo": "nix-ld-rs",
-        "rev": "ce02bc08397af64ba2487e229f3b67498581a884",
+        "rev": "5b6dc9fbe9436984d80e62a1618fddda4797e539",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                           |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`5b6dc9fb`](https://github.com/nix-community/nix-ld-rs/commit/5b6dc9fbe9436984d80e62a1618fddda4797e539) | `` chore(deps): update rust crate cc to v1.1.1 `` |