### PR TITLE
chore(flake/nixpkgs): `249fbde2` -> `a046c120`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1720553833,
-        "narHash": "sha256-IXMiHQMtdShDXcBW95ctA+m5Oq2kLxnBt7WlMxvDQXA=",
+        "lastModified": 1720691131,
+        "narHash": "sha256-CWT+KN8aTPyMIx8P303gsVxUnkinIz0a/Cmasz1jyIM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "249fbde2a178a2ea2638b65b9ecebd531b338cf9",
+        "rev": "a046c1202e11b62cbede5385ba64908feb7bfac4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`23b501cb`](https://github.com/NixOS/nixpkgs/commit/23b501cb602d63b4ac896b76de9a124dc7c0a17d) | `` pt2-clone: fix NixOS test failure due to whitespace in icon name ``      |
| [`e9e6878e`](https://github.com/NixOS/nixpkgs/commit/e9e6878e5129efa55fe13a9b8b496d04a9df096b) | `` flake.nix: remove power64 from from nixos check due to broken package `` |
| [`fb343de8`](https://github.com/NixOS/nixpkgs/commit/fb343de8252c0e9613d0b0d354cac210dcf37f46) | `` lib.systems.flakeExposed: exclude systems which are not bootstrapped ``  |
| [`c23dba8f`](https://github.com/NixOS/nixpkgs/commit/c23dba8fcf323852be9b733b2a7cf3b9c04b9c57) | `` coredns: add nixosTests.kubernetes dns tests to passthru.tests ``        |
| [`2fafa4b5`](https://github.com/NixOS/nixpkgs/commit/2fafa4b5f3643052a627031fe1042de6c6fa344f) | `` coredns: 1.11.1 -> 1.11.3 ``                                             |
| [`d85399b9`](https://github.com/NixOS/nixpkgs/commit/d85399b969525dc8d6304deaf5aabec9aa1435f0) | `` openbsd: Add static linking support ``                                   |
| [`81e97042`](https://github.com/NixOS/nixpkgs/commit/81e97042bb7a86a4a040266c0e3fdc12a9efde74) | `` yt-dlp: 2024.7.7 -> 2024.7.9 ``                                          |
| [`f95457b3`](https://github.com/NixOS/nixpkgs/commit/f95457b3e8910c0073aa069443488ca2c907b0d1) | `` [24.05] nixos/ollama: make overrides compatible with unstable package `` |
| [`eb72e90f`](https://github.com/NixOS/nixpkgs/commit/eb72e90f0b3dc3faec478d1d037aa7e2ac0eaedf) | `` open62541: 1.4.1 -> 1.4.2 ``                                             |
| [`53427bd0`](https://github.com/NixOS/nixpkgs/commit/53427bd097af8e6eca557d390cd40b2017b9b382) | `` gruvbox-gtk-theme: 0-unstable-2023-05-28 -> 0-unstable-2024-06-27 ``     |
| [`e551c372`](https://github.com/NixOS/nixpkgs/commit/e551c3727e2dfa1b681b4c5dc5f7afc12017e01e) | `` cfdyndns: 0.2.0 -> 0.2.1 ``                                              |
| [`f87723da`](https://github.com/NixOS/nixpkgs/commit/f87723da58c9c8da607cec164ed9a1dbc2d9f4fc) | `` element-desktop: 1.11.69 -> 1.11.70 ``                                   |
| [`a50ae77e`](https://github.com/NixOS/nixpkgs/commit/a50ae77e2daefbb8ab25142acb2811c1b679f32a) | `` xh: 0.22.0 -> 0.22.2 ``                                                  |
| [`3b1aeab1`](https://github.com/NixOS/nixpkgs/commit/3b1aeab1bb5e421854eecb921b593a14043b441e) | `` lomiri.telephony-service: Fetch patch to fix build ``                    |
| [`7d1b7423`](https://github.com/NixOS/nixpkgs/commit/7d1b7423befec83230e6431d677e79b3f4bb0481) | `` Revert "lomiri.lomiri-indicator-network: Disable tests" ``               |
| [`327e47ef`](https://github.com/NixOS/nixpkgs/commit/327e47ef03b687dffd8010a1aae9e33feba7c96f) | `` Revert "lomiri.telephony-service: Mark broken & exclude everywhere" ``   |
| [`467e4333`](https://github.com/NixOS/nixpkgs/commit/467e433357307f6a937fbf5ab865835270394354) | `` profiles/qemu_guest: add virtio_gpu to initrd ``                         |
| [`3b6aec24`](https://github.com/NixOS/nixpkgs/commit/3b6aec240d2a09347509abd3e3e29c8dc08e133d) | `` firefox-esr-128-unwrapped: init at 128.0esr ``                           |
| [`e1078666`](https://github.com/NixOS/nixpkgs/commit/e1078666fe61061e6f635bfc5f330387363c2a9a) | `` firefox-esr-115-unwrapped: 115.12.0esr -> 115.13.0esr ``                 |
| [`082ea57c`](https://github.com/NixOS/nixpkgs/commit/082ea57cbae92e582e57816f56bbfb2e5c1d203f) | `` firefox-unwrapped: 127.0.2 -> 128.0 ``                                   |
| [`ec296e00`](https://github.com/NixOS/nixpkgs/commit/ec296e00bcdbc446478911b7bd29b8311a811b8e) | `` linuxKernel.kernels.linux_lqx: 6.9.7-lqx1 -> 6.9.8-lqx1 ``               |
| [`b6e8b44d`](https://github.com/NixOS/nixpkgs/commit/b6e8b44d5ec673bce1a0f6f68121d458c52af12c) | `` linuxKernel.kernels.linux_zen: 6.9.7-zen1 -> 6.9.8-zen1 ``               |
| [`0a9a3f91`](https://github.com/NixOS/nixpkgs/commit/0a9a3f917ac04aa6a3961ae0703880f4774cf9b1) | `` protonmail-desktop: 1.0.3 -> 1.0.4 ``                                    |
| [`41ef0e02`](https://github.com/NixOS/nixpkgs/commit/41ef0e02f060827317ad03386711ae589c6e96e3) | `` nixos/peering-manager: add oidc support ``                               |
| [`61af1cf1`](https://github.com/NixOS/nixpkgs/commit/61af1cf10ae7852b32411321f53a3a06d39e6e5b) | `` mozilla-django-oidc: init at 4.0.1 ``                                    |
| [`6e1f71da`](https://github.com/NixOS/nixpkgs/commit/6e1f71da7ac85a5dc1f4ab9836fd6a2db1f2973c) | `` maintainers: add felbinger ``                                            |