### PR TITLE
chore(flake/nixpkgs): `a046c120` -> `f12ee5f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1720691131,
-        "narHash": "sha256-CWT+KN8aTPyMIx8P303gsVxUnkinIz0a/Cmasz1jyIM=",
+        "lastModified": 1720823163,
+        "narHash": "sha256-FZ5dnrvKkln9ESdoTR8R7GKW9rNpXNZrxGsOXsbsTpE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a046c1202e11b62cbede5385ba64908feb7bfac4",
+        "rev": "f12ee5f64c6a09995e71c9626d88c4efa983b488",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                              |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`78f1351f`](https://github.com/NixOS/nixpkgs/commit/78f1351fffa52440b9ea1f3d6ff8927d876c4271) | `` maintainer-list: Fix formatting ``                                |
| [`a05370c8`](https://github.com/NixOS/nixpkgs/commit/a05370c8c5a4e185a5fcbdddae2cbeb7cd04363e) | `` vscode-extensions.phind.phind: 0.22.2 -> 0.25.3 ``                |
| [`8ca91f3a`](https://github.com/NixOS/nixpkgs/commit/8ca91f3adbcb84e58a4174c5a188d4f8f131eeb8) | `` epson-escpr2: 1.2.11 -> 1.2.12 ``                                 |
| [`f5a73cb5`](https://github.com/NixOS/nixpkgs/commit/f5a73cb5089392a676547dc0acf202c037812cad) | `` epson-escpr2: format with nixfmt-rfc-style ``                     |
| [`80336b45`](https://github.com/NixOS/nixpkgs/commit/80336b45780f93df1fb6cde29e0b7c6d77033fc9) | `` lix: 2.90.0-rc1 -> 2.90.0 ``                                      |
| [`fd5b6bb2`](https://github.com/NixOS/nixpkgs/commit/fd5b6bb244b132ada97f7e259b5c3acd2e0193af) | `` {tor,mullvad}-browser: migrate to pkgs/by-name ``                 |
| [`02555f11`](https://github.com/NixOS/nixpkgs/commit/02555f11078f9d3b1a44c8d8f0aff1f67d138ce2) | `` mullvad-browser: 13.5 -> 13.5.1 ``                                |
| [`9c52009c`](https://github.com/NixOS/nixpkgs/commit/9c52009c890ae725422d42039b4660d7d38cdf81) | `` tor-browser: 13.5 -> 13.5.1 ``                                    |
| [`5dfc4498`](https://github.com/NixOS/nixpkgs/commit/5dfc4498ee2d29210ac493ff18d103676a061f33) | `` miniflux: 2.1.3 -> 2.1.4 ``                                       |
| [`6db47412`](https://github.com/NixOS/nixpkgs/commit/6db47412aefe0ea28bd37b3d84c93bf9c2bcb0e2) | `` viceroy: 0.9.7 -> 0.10.0 ``                                       |
| [`b9ae4aaa`](https://github.com/NixOS/nixpkgs/commit/b9ae4aaa54b9efcb693cf1744335c7db86ce2617) | `` pkgsCross.aarch64-darwin.discord-development: 0.0.43 -> 0.0.44 `` |
| [`4c75ae16`](https://github.com/NixOS/nixpkgs/commit/4c75ae16cc6f1164fc9c84792c181eacdb558a51) | `` pkgsCross.aarch64-darwin.discord-canary: 0.0.547 -> 0.0.559 ``    |
| [`0c30bba9`](https://github.com/NixOS/nixpkgs/commit/0c30bba9708b84c8eb7dcd81f666937893324389) | `` pkgsCross.aarch64-darwin.discord-ptb: 0.0.121 -> 0.0.122 ``       |
| [`0e21682f`](https://github.com/NixOS/nixpkgs/commit/0e21682ff1741736b76ee3c040aecf5dc74cdb2a) | `` pkgsCross.aarch64-darwin.discord: 0.0.309 -> 0.0.310 ``           |
| [`9679441d`](https://github.com/NixOS/nixpkgs/commit/9679441d0f7f134f4353442442ca44aff01b9667) | `` discord-development: 0.0.21 -> 0.0.22 ``                          |
| [`46ea4751`](https://github.com/NixOS/nixpkgs/commit/46ea4751c996bcc9a4e418ab50475c6f6251b5d4) | `` discord-canary: 0.0.438 -> 0.0.450 ``                             |
| [`95cacf76`](https://github.com/NixOS/nixpkgs/commit/95cacf76568c6cb9772c7cffa83ca75497843cd2) | `` discord-ptb: 0.0.92 -> 0.0.93 ``                                  |
| [`e33261e7`](https://github.com/NixOS/nixpkgs/commit/e33261e74d3026c0370e96435851c8b37ea81ca1) | `` discord: 0.0.58 -> 0.0.59 ``                                      |
| [`0a193367`](https://github.com/NixOS/nixpkgs/commit/0a193367658061914e877c4373fc3885cd8d0a05) | `` linux/hardened: fix syntax in update-script ``                    |
| [`896a260d`](https://github.com/NixOS/nixpkgs/commit/896a260d9a851b18dad3a6d2cc1cb8e304f176fc) | `` linux_latest-libre: 19584 -> 19597 ``                             |
| [`4838d529`](https://github.com/NixOS/nixpkgs/commit/4838d529064b68b5ee140bf14a773279f401792c) | `` linux-rt_5_10: 5.10.219-rt111 -> 5.10.220-rt112 ``                |
| [`3c747708`](https://github.com/NixOS/nixpkgs/commit/3c747708f83e12b08bb6f4ecfc650720b1b10e59) | `` linux_6_1: 6.1.97 -> 6.1.98 ``                                    |
| [`f5e9a7ca`](https://github.com/NixOS/nixpkgs/commit/f5e9a7caf264338b6580075ce4d5736c56bf170a) | `` linux_6_6: 6.6.37 -> 6.6.39 ``                                    |
| [`95ec60ca`](https://github.com/NixOS/nixpkgs/commit/95ec60ca9fa1a7dc3c8e16e5856891ae89fc53e8) | `` linux_6_9: 6.9.8 -> 6.9.9 ``                                      |
| [`9b876f3b`](https://github.com/NixOS/nixpkgs/commit/9b876f3bb364963e705719be866ad311ec366d12) | `` linux_testing: 6.10-rc6 -> 6.10-rc7 ``                            |
| [`68fdfb07`](https://github.com/NixOS/nixpkgs/commit/68fdfb07f57dc1e8a9abd99f0c68dff7f61c7fe9) | `` nixVersions.nix_2_22: 2.22.2 -> 2.22.3 ``                         |
| [`3819697a`](https://github.com/NixOS/nixpkgs/commit/3819697a6ba8b9ff56c98cba277d14ccdc0c6317) | `` nixVersions.nix_2_21: 2.21.3 -> 2.21.4 ``                         |
| [`dc1987c1`](https://github.com/NixOS/nixpkgs/commit/dc1987c126feb057e27bb99537ca196989e7d9a6) | `` nixVersions.nix_2_20: 2.20.7 -> 2.20.8 ``                         |
| [`32de9875`](https://github.com/NixOS/nixpkgs/commit/32de9875b3d683b64bf10249956dfddfc696cf54) | `` nixVersions.nix_2_19: 2.19.5 -> 2.19.6 ``                         |
| [`d0ffbb70`](https://github.com/NixOS/nixpkgs/commit/d0ffbb70f153fa2797edf15f141ac7a35c4d8bfd) | `` prometheus: 2.53.0 → 2.53.1 ``                                    |
| [`277e33f2`](https://github.com/NixOS/nixpkgs/commit/277e33f286f11e5dd01ca5dee0dd35142f40be5a) | `` rustdesk-flutter: explicitly use fuse3 (#326144) ``               |
| [`356cab29`](https://github.com/NixOS/nixpkgs/commit/356cab293f359e6f9eca5127ece92e447340b33a) | `` neothesia: install icon ``                                        |
| [`5d0e1368`](https://github.com/NixOS/nixpkgs/commit/5d0e136809e765bddcf1b7bc8d937ccccc2a42a3) | `` prometheus: 2.52.0 → 2.53.0 ``                                    |
| [`d93d40d8`](https://github.com/NixOS/nixpkgs/commit/d93d40d89a65adcf03d5c34b2bcb2fd676b4322f) | `` python312Packages.django_5: 5.0.5 -> 5.0.7 ``                     |
| [`636b92eb`](https://github.com/NixOS/nixpkgs/commit/636b92ebfb4f5f64a53bfeb04a958e467d49df84) | `` aegisub: fix build on darwin ``                                   |
| [`10659bf3`](https://github.com/NixOS/nixpkgs/commit/10659bf34ebf8017c2c2eee66262a4abbaa805fa) | `` opentelemetry-collector: apply patch for CVE-2024-36129 ``        |
| [`3463598a`](https://github.com/NixOS/nixpkgs/commit/3463598aea897810759bebbf9f011221ab802944) | `` sweet: 4.0 -> 5.0 ``                                              |
| [`f24030e5`](https://github.com/NixOS/nixpkgs/commit/f24030e56f7b6d8476bd72e0816dd42e11a3777d) | `` rbw: 1.10.2 -> 1.11.1 ``                                          |
| [`a05cac8b`](https://github.com/NixOS/nixpkgs/commit/a05cac8b9d01d277d4ad15a9d88aec51403f5f64) | `` epson-escpr2: 1.2.10 -> 1.2.11 ``                                 |