### PR TITLE
chore(flake/nixpkgs): `f12ee5f6` -> `53e81e79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1720823163,
-        "narHash": "sha256-FZ5dnrvKkln9ESdoTR8R7GKW9rNpXNZrxGsOXsbsTpE=",
+        "lastModified": 1720954236,
+        "narHash": "sha256-1mEKHp4m9brvfQ0rjCca8P1WHpymK3TOr3v34ydv9bs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f12ee5f64c6a09995e71c9626d88c4efa983b488",
+        "rev": "53e81e790209e41f0c1efa9ff26ff2fd7ab35e27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                              |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
| [`4e65f7cf`](https://github.com/NixOS/nixpkgs/commit/4e65f7cfc90b5f3a632746cfc5db93bedc507306) | `` python313FreeThreading: init ``                                                                                   |
| [`d5dabf40`](https://github.com/NixOS/nixpkgs/commit/d5dabf4000e6795f8d18c2f179add38a53babb5c) | `` nix-fast-build: init at 1.0.0 ``                                                                                  |
| [`1a7bf297`](https://github.com/NixOS/nixpkgs/commit/1a7bf297da78ae6cc3084b9b351bb120ec441724) | `` osinfo-db: 20240523 -> 20240701 ``                                                                                |
| [`228192ba`](https://github.com/NixOS/nixpkgs/commit/228192ba58c4d6f8559e51bdd93cedd8b359473c) | `` metal-cli: 0.23.0 -> 0.23.1 ``                                                                                    |
| [`68c6b3ca`](https://github.com/NixOS/nixpkgs/commit/68c6b3ca5da36c8c579376099691f3fe51a0070c) | `` osinfo-db: 20240510 -> 20240523 ``                                                                                |
| [`1d6bff78`](https://github.com/NixOS/nixpkgs/commit/1d6bff78027aa9bd9279e92f94ed81ffcff37d72) | `` pipe-viewer: remove dependency on youtube-dl ``                                                                   |
| [`a67a9be3`](https://github.com/NixOS/nixpkgs/commit/a67a9be3715300f6f8227334deba842306f6f04c) | `` [Backport release-24.05] itsycal: rfc format; itsycal: add meta.changelog; ityscal: 0.15.3 -> 0.15.4 (#326625) `` |
| [`5582e2c9`](https://github.com/NixOS/nixpkgs/commit/5582e2c97f63327758580c9e32dbcb99a08d7de8) | `` viceroy: 0.10.0 -> 0.10.1 ``                                                                                      |
| [`70bedd51`](https://github.com/NixOS/nixpkgs/commit/70bedd515a69f36adcee305eb4b3c8bb74ad5a48) | `` xorg.libXpresent: add xorg.libXfixes to propagated build inputs ``                                                |
| [`2f844819`](https://github.com/NixOS/nixpkgs/commit/2f8448199b1305b36ece7baf1654a2f4e68824a6) | `` [24.05] inotify-info 0.0.1 -> 0.0.3 ``                                                                            |
| [`406d33ba`](https://github.com/NixOS/nixpkgs/commit/406d33ba5a61c043bcc4411739b53b12f2448c10) | `` angie: 1.5.2 -> 1.6.0 ``                                                                                          |