### PR TITLE
chore(flake/nur): `9ef59e0c` -> `245f3637`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -380,11 +380,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720730413,
-        "narHash": "sha256-yyeOrroMYTugTe+a3pTIxWb2zi+jJtxjuZrKguXFARQ=",
+        "lastModified": 1721225625,
+        "narHash": "sha256-a4XBoM9dci1MW0KaaI+qz2KsI6oQ2+dEcZlOZZRfuDA=",
         "owner": "0x61nas",
         "repo": "nur",
-        "rev": "9ef59e0c19f9328e54dec038d2b5afb19bcbf428",
+        "rev": "245f3637d25d89cf2b70bfca88901fb628948669",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                       | Message                                |
| -------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`245f3637`](https://github.com/0x61nas/nur/commit/245f3637d25d89cf2b70bfca88901fb628948669) | `` lpl: init at 0.1.0 ``               |
| [`c2c59abb`](https://github.com/0x61nas/nur/commit/c2c59abb1441131e45ac3d8ef7e93ffa9a9bb072) | `` ducker: 0.0.5 -> 0.0.6 ``           |
| [`d34f0b70`](https://github.com/0x61nas/nur/commit/d34f0b701723f13f335f2f250392f2333f42c885) | `` chore(flake.lock): update inputs `` |