### PR TITLE
chore(flake/nur): `9ef59e0c` -> `f070ea03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -380,11 +380,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720730413,
-        "narHash": "sha256-yyeOrroMYTugTe+a3pTIxWb2zi+jJtxjuZrKguXFARQ=",
+        "lastModified": 1721231413,
+        "narHash": "sha256-b5iIUzj1itgQhpTuiiakmlcutISFgvNb7DMKvUI1gNI=",
         "owner": "0x61nas",
         "repo": "nur",
-        "rev": "9ef59e0c19f9328e54dec038d2b5afb19bcbf428",
+        "rev": "f070ea0372332299a0245a42a2640893dff9a297",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                       | Message                                |
| -------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`f070ea03`](https://github.com/0x61nas/nur/commit/f070ea0372332299a0245a42a2640893dff9a297) | `` lpl: init at 0.1.0 ``               |
| [`17cae5fa`](https://github.com/0x61nas/nur/commit/17cae5fa9043b912424fb8afc4cf663bfb1c5772) | `` ducker: 0.0.5 -> 0.0.6 ``           |
| [`d34f0b70`](https://github.com/0x61nas/nur/commit/d34f0b701723f13f335f2f250392f2333f42c885) | `` chore(flake.lock): update inputs `` |