### PR TITLE
chore(flake/nix-ld-rs): `befdf953` -> `2f1fe38b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721014541,
-        "narHash": "sha256-CaL618a842JxU69/c9U7TysASx51LeFR4TwAai3YBfI=",
+        "lastModified": 1721394956,
+        "narHash": "sha256-VnayJVKngasaNNiMlBhkeA//+V9EpEuT/mkOsFUbFDg=",
         "owner": "nix-community",
         "repo": "nix-ld-rs",
-        "rev": "befdf953399eeff2c4e7c5a2b63af964ad209269",
+        "rev": "2f1fe38bc69d2400652e0848d9d2ce2955a39cf6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                           |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`2f1fe38b`](https://github.com/nix-community/nix-ld-rs/commit/2f1fe38bc69d2400652e0848d9d2ce2955a39cf6) | `` chore(deps): update rust crate cc to v1.1.6 `` |