### PR TITLE
chore(flake/nixpkgs): `53e81e79` -> `a1cc729d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1720954236,
-        "narHash": "sha256-1mEKHp4m9brvfQ0rjCca8P1WHpymK3TOr3v34ydv9bs=",
+        "lastModified": 1721949857,
+        "narHash": "sha256-DID446r8KsmJhbCzx4el8d9SnPiE8qa6+eEQOJ40vR0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "53e81e790209e41f0c1efa9ff26ff2fd7ab35e27",
+        "rev": "a1cc729dcbc31d9b0d11d86dc7436163548a9665",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
| [`290dd599`](https://github.com/NixOS/nixpkgs/commit/290dd599d988aeada0eb6db8e75d91b431210bd1) | `` nixosTests.gitlab: add git package ``                                                               |
| [`7f19bbe2`](https://github.com/NixOS/nixpkgs/commit/7f19bbe2159f0af2813717226b8cc3eab633fd4b) | `` nixos/gitlab: Replace git package with bundled git ``                                               |
| [`1193be84`](https://github.com/NixOS/nixpkgs/commit/1193be84feacd768fa325c53f51e3990ee64e3d0) | `` gitaly: build bundled git from source ``                                                            |
| [`7d107ff9`](https://github.com/NixOS/nixpkgs/commit/7d107ff9807da04dd558ea8318a5783458ae22e5) | `` electron: support updating chromedriver with update.py ``                                           |
| [`766b80ba`](https://github.com/NixOS/nixpkgs/commit/766b80bae9a87e9d82799e1caf279126b5c5efbf) | `` electron-chromedriver: init at 29.4.4, 30.2.0, 31.2.0 ``                                            |
| [`ef09db1a`](https://github.com/NixOS/nixpkgs/commit/ef09db1a0fb6e0881707b2b997d35c3c79247859) | `` maintainers: add liammurphy14 ``                                                                    |
| [`11eb0248`](https://github.com/NixOS/nixpkgs/commit/11eb02484b372c871d75c28c0f96cea5e6e5b55a) | `` electron: fix update script ``                                                                      |
| [`2df31b0d`](https://github.com/NixOS/nixpkgs/commit/2df31b0d428ddce64ebfc21e89f6d9cd209f32c5) | `` linux_latest-libre: 19611 -> 19618 ``                                                               |
| [`5bd8c915`](https://github.com/NixOS/nixpkgs/commit/5bd8c915fb3ea4467e2d2bd5eadf65c76384fb40) | `` linux-rt_6_6: 6.6.40-rt36 -> 6.6.41-rt37 ``                                                         |
| [`10d4654d`](https://github.com/NixOS/nixpkgs/commit/10d4654d68d5d67e096ba4980e9ed4219f8c9e4f) | `` linux_6_1: 6.1.100 -> 6.1.101 ``                                                                    |
| [`2ba26731`](https://github.com/NixOS/nixpkgs/commit/2ba267319c099b0f4ca31333a56234d5a8c3fa4f) | `` linux_6_6: 6.6.41 -> 6.6.42 ``                                                                      |
| [`aa71bf89`](https://github.com/NixOS/nixpkgs/commit/aa71bf893a34dd020fc6db88cfc4cb64840c716a) | `` linux_6_9: 6.9.10 -> 6.9.11 ``                                                                      |
| [`90ea2e57`](https://github.com/NixOS/nixpkgs/commit/90ea2e57fa575ef8447ff7126c76fe76c8e9b5b6) | `` linux_6_10: 6.10 -> 6.10.1 ``                                                                       |
| [`ad56d10d`](https://github.com/NixOS/nixpkgs/commit/ad56d10dca7b7c87df782219f410c9d1523fb815) | `` poppler: add more key reverse-dependencies to passthru.tests ``                                     |
| [`284073a2`](https://github.com/NixOS/nixpkgs/commit/284073a25a0ba886d35fa159d04445abb6252a8d) | `` gitlab: 17.1.2 -> 17.2.0 ``                                                                         |
| [`5eefee11`](https://github.com/NixOS/nixpkgs/commit/5eefee11a3ffcc42a33963a5c88a24aab38bdf47) | `` llvm_18, lld_18: Patch to support more OpenBSD sections ``                                          |
| [`e389ca91`](https://github.com/NixOS/nixpkgs/commit/e389ca91e9fd96c2b80fbfa15c060387523c2f05) | `` arc-browser: 1.51.0-51691 -> 1.52.0-51895 ``                                                        |
| [`387a5614`](https://github.com/NixOS/nixpkgs/commit/387a561429d6aa27611c2b0d03fb05604ac09bdd) | `` overrideSDK: fix missing host platform inside of override ``                                        |
| [`441df694`](https://github.com/NixOS/nixpkgs/commit/441df694a46b387e6d5be12778f3148213b6737a) | `` llvmPackages_{13,14,15,16,17,18,git}: commonify the default.nix ``                                  |
| [`6378f52d`](https://github.com/NixOS/nixpkgs/commit/6378f52dc8eeeed76577209768edf35756531cba) | `` clang-tools_*: move to aliases ``                                                                   |
| [`42eaf65f`](https://github.com/NixOS/nixpkgs/commit/42eaf65fe998e9fc985868849d3b9279ebc9674f) | `` clang-tools: move into llvmPackages ``                                                              |
| [`ffeb5e9c`](https://github.com/NixOS/nixpkgs/commit/ffeb5e9cf29466a65093916c31e08ea2f626d2c5) | `` clang-tools: format with nixfmt (Nix RFC 166) ``                                                    |
| [`be4fb261`](https://github.com/NixOS/nixpkgs/commit/be4fb261bd5de9f74e6aeacd1b4f7eceeb556648) | `` discord-canary: 0.0.453 -> 0.0.455 ``                                                               |
| [`ace0e785`](https://github.com/NixOS/nixpkgs/commit/ace0e7855432ab60b7233981ff74acab5d63ebee) | `` prometheus-knot-exporter: 3.3.7 -> 3.3.8 ``                                                         |
| [`8bde2516`](https://github.com/NixOS/nixpkgs/commit/8bde25163e371c2443d523384cdcb425a48e8eeb) | `` prometheus-knot-exporter: 3.3.6 -> 3.3.7 ``                                                         |
| [`cffc0588`](https://github.com/NixOS/nixpkgs/commit/cffc0588379c2c41190a26ee6938230030fc6b4a) | `` python312Packages.libknot: 3.3.7 -> 3.3.8 ``                                                        |
| [`c5d5a6c8`](https://github.com/NixOS/nixpkgs/commit/c5d5a6c83ea59817ec7d70b8fc22753649a25146) | `` maintainers: add redhawk as a xmrig-mo maintainer ``                                                |
| [`837f5df7`](https://github.com/NixOS/nixpkgs/commit/837f5df7869d74b46f6d16e651054977045eebc4) | `` xmrig-mo: 6.21.0-mo2 -> 6.21.3-mo15 ``                                                              |
| [`d1121cde`](https://github.com/NixOS/nixpkgs/commit/d1121cde7c75dcc63ef94b91132d91e65fd06828) | `` gajim: 1.9.1 - > 1.9.2 ``                                                                           |
| [`ba2c700f`](https://github.com/NixOS/nixpkgs/commit/ba2c700f109691dfaf556ca6c2ff0062f69e8778) | `` firefox-bin-unwrapped: 128.0 -> 128.0.2 ``                                                          |
| [`48057c8f`](https://github.com/NixOS/nixpkgs/commit/48057c8f1b71cc787a9a94e195624874b0467868) | `` firefox-bin-unwrapped: 127.0.2 -> 128.0 ``                                                          |
| [`16f30f4f`](https://github.com/NixOS/nixpkgs/commit/16f30f4f71f155cca858d8ee5af8cf3395d0196c) | `` firefox-unwrapped: 128.0 -> 128.0.2 ``                                                              |
| [`448dea1c`](https://github.com/NixOS/nixpkgs/commit/448dea1cc740fbf36807bc5b7dbfc290d6674917) | `` python312Packages.mautrix: 0.20.4 -> 0.20.6 ``                                                      |
| [`213df4a2`](https://github.com/NixOS/nixpkgs/commit/213df4a22603c7f106fcd5a8a0956160a5bdebd6) | `` maxima: add patch for CVE-2024-34490 ``                                                             |
| [`5555ad6b`](https://github.com/NixOS/nixpkgs/commit/5555ad6b3bd0f860947b1f6b1cdf7d88209c06ac) | `` graylog-5_2: 5.2.7 -> 5.2.9 ``                                                                      |
| [`26805db7`](https://github.com/NixOS/nixpkgs/commit/26805db73c4e67c9f66cb5553ab53e4b582cbcd7) | `` graylog: refactor hash attribute ``                                                                 |
| [`38c6c048`](https://github.com/NixOS/nixpkgs/commit/38c6c0480364a6a6a813869d952e9e669f68db3b) | `` knot-resolver: 5.7.3 -> 5.7.4 ``                                                                    |
| [`2f84187a`](https://github.com/NixOS/nixpkgs/commit/2f84187ab79d1d895a046f4000d0a4c2eecac775) | `` knot-dns: 3.3.7 -> 3.3.8 ``                                                                         |
| [`b45c1836`](https://github.com/NixOS/nixpkgs/commit/b45c1836e5674f85fcd467addbdeeb01c3f45453) | `` meshcentral: 1.1.24 -> 1.1.26 ``                                                                    |
| [`300e06cf`](https://github.com/NixOS/nixpkgs/commit/300e06cf5691eb081896c9c0b3a5ed70e15b9ccf) | `` xdg-desktop-portal-hyprland: add security patch ``                                                  |
| [`11e63948`](https://github.com/NixOS/nixpkgs/commit/11e63948e41ac74d98cc838411c732cb4f822c47) | `` kodiPackages.sendtokodi: remove dependency on youtube_dl ``                                         |
| [`64c16e0e`](https://github.com/NixOS/nixpkgs/commit/64c16e0ef1d13cc716946b6ffab0e54a0ebec157) | `` flyctl: 0.2.88 -> 0.2.94 ``                                                                         |
| [`2faa9a19`](https://github.com/NixOS/nixpkgs/commit/2faa9a190282cb7012e4abf443906f2b80c5b817) | `` bind: 9.18.27 -> 9.18.28 ``                                                                         |
| [`4b7696fc`](https://github.com/NixOS/nixpkgs/commit/4b7696fc44862fa9a43b2c2ea803a890544aba8a) | `` iperf3: reformat ``                                                                                 |
| [`610555ad`](https://github.com/NixOS/nixpkgs/commit/610555ad4ae680190d9d6f208597f0ed69c08178) | `` iperf3: 3.16 -> 3.17.1 ``                                                                           |
| [`9e748e3b`](https://github.com/NixOS/nixpkgs/commit/9e748e3b51030a0a30e4cb2a74d412e568d4e9b3) | `` viceroy: 0.10.1 -> 0.10.2 ``                                                                        |
| [`ade4958b`](https://github.com/NixOS/nixpkgs/commit/ade4958b3f32583dae470e906924121f58e99e42) | `` kerberos/heimdal: use jdk_headless in nativeCheckInputs (#329158) (#329395) ``                      |
| [`babc9411`](https://github.com/NixOS/nixpkgs/commit/babc94115fd1c0dbb73bee777dd3c06298ff1291) | `` firefly-iii: 6.1.18 -> 6.1.19 ``                                                                    |
| [`4fdb8ffc`](https://github.com/NixOS/nixpkgs/commit/4fdb8ffc8d0779308bf1266ddd086b7a98da33cd) | `` nixos/graylog: add option dataDir ``                                                                |
| [`82314e90`](https://github.com/NixOS/nixpkgs/commit/82314e909637b3634fc166a3cc8384ed74973e5e) | `` graylog-6_0: init at 6.0.4 ``                                                                       |
| [`1528cc8b`](https://github.com/NixOS/nixpkgs/commit/1528cc8b81336a58f4df8ab0369869be57e14154) | `` k3s_1_28: 1.28.11+k3s1 -> 1.28.11+k3s2 ``                                                           |
| [`c8d989e9`](https://github.com/NixOS/nixpkgs/commit/c8d989e9434152fae86cccefcbb12216cd8fa0a4) | `` spotify: 1.2.37.701.ge66eb7bc -> 1.2.40.599.g606b7f29 ``                                            |
| [`8dbf3bbc`](https://github.com/NixOS/nixpkgs/commit/8dbf3bbcd5b541448289367eb8eee99877362d76) | `` gajim: 1.9.0 -> 1.9.1, nbxmpp: 5.0.0 - > 5.0.1 ``                                                   |
| [`666e2b75`](https://github.com/NixOS/nixpkgs/commit/666e2b75a124a2ab81b12121143f7de17de3ab08) | `` pegtl: init at 2.3.7 ``                                                                             |
| [`56da8bd4`](https://github.com/NixOS/nixpkgs/commit/56da8bd4caff783942257c3e206d2f00d0c53a4d) | `` signal-desktop-beta: 7.16.0-beta.1 -> 7.17.0-beta.1 ``                                              |
| [`b9ce4df7`](https://github.com/NixOS/nixpkgs/commit/b9ce4df7bce66f0195287f151196bba58fdab852) | `` signal-desktop: 7.15.0 -> 7.16.0 ``                                                                 |
| [`ea73e7ae`](https://github.com/NixOS/nixpkgs/commit/ea73e7ae9dea53d112cb08fb78f4e00d1f686c54) | `` nixos/dictd: treat SIGTERM exit status as success ``                                                |
| [`e2afad11`](https://github.com/NixOS/nixpkgs/commit/e2afad11d1aa1e7693e4989050b0c4f3ba5723d2) | `` nextcloud29: 29.0.3 -> 29.0.4 ``                                                                    |
| [`f01f7cde`](https://github.com/NixOS/nixpkgs/commit/f01f7cde710881ee7562a116b611e469b83e2b11) | `` nextcloud28: 28.0.7 -> 28.0.8 ``                                                                    |
| [`5a1d5244`](https://github.com/NixOS/nixpkgs/commit/5a1d524407a7ffda5b49e06aa923a84ae059c9ef) | `` python3Packages.deltalake: Fix deltalake for nixos-24.05 ``                                         |
| [`d2c67b70`](https://github.com/NixOS/nixpkgs/commit/d2c67b703fe7745590ea7519c54f7a3d1c05a2ba) | `` python311Packages.deltalake: fix build on darwin ``                                                 |
| [`5979c385`](https://github.com/NixOS/nixpkgs/commit/5979c385d6b434865aa7471a2c0235cf9fad30c5) | `` mautrix-signal: 0.6.1 -> 0.6.3 ``                                                                   |
| [`376ebe90`](https://github.com/NixOS/nixpkgs/commit/376ebe900dc34b42781ead894465665dbf26150e) | `` libsignal-ffi: 0.44.0 -> 0.52.0 ``                                                                  |
| [`ce69bd13`](https://github.com/NixOS/nixpkgs/commit/ce69bd13dddad0c569dbd01b3764518c49d74759) | `` mautrix-telegram: 0.15.1 -> 0.15.2 ``                                                               |
| [`5cdfca18`](https://github.com/NixOS/nixpkgs/commit/5cdfca18d073c9b5460b594a168aba6d42e797f2) | `` strace: 6.9 -> 6.10 ``                                                                              |
| [`703f7bf7`](https://github.com/NixOS/nixpkgs/commit/703f7bf75a159d7a84f199e475d5c1ed05f6c99e) | `` paperless-ngx: 2.10.1 -> 2.10.2 ``                                                                  |
| [`9b9690d7`](https://github.com/NixOS/nixpkgs/commit/9b9690d7ae03f608301178f720bdfd9aff6d2958) | `` outline: 0.77.2 -> 0.78.0 and set updateScript ``                                                   |
| [`c6f192bb`](https://github.com/NixOS/nixpkgs/commit/c6f192bb4759095a0ead60f87c0e1021fae489b6) | `` bcachefs-tools: 1.9.3 -> 1.9.4 ``                                                                   |
| [`b703341d`](https://github.com/NixOS/nixpkgs/commit/b703341dba5a5f5eba9cef1c751c0791ecfc9b9a) | `` bcachefs-tools: add version-test and mainProgram ``                                                 |
| [`540b066c`](https://github.com/NixOS/nixpkgs/commit/540b066cec64b27afc10f7c5ab3a65060896a89e) | `` bcachefs-tools: add fish,bash,zsh completions ``                                                    |
| [`fcfbf362`](https://github.com/NixOS/nixpkgs/commit/fcfbf36275fa2ba73d68315dab98ffc43f4dd8b3) | `` bcachefs-tools: 1.9.2 -> 1.9.3 ``                                                                   |
| [`515f58c7`](https://github.com/NixOS/nixpkgs/commit/515f58c79ffed15fd5ac77d8a08af2ed5cfb4ea2) | `` bcachefs-tools: 1.7.0-unstable-2024-05-09 -> 1.9.2 ``                                               |
| [`fed55ae5`](https://github.com/NixOS/nixpkgs/commit/fed55ae595b18194eabb800f9b4d39848ffc1850) | `` bcachefs-tools: Fix cross ``                                                                        |
| [`6ada06b9`](https://github.com/NixOS/nixpkgs/commit/6ada06b972b474fa1a53fd733a798525a1813d07) | `` linux_xanmod_latest: 6.9.9 -> 6.9.10 ``                                                             |
| [`ff259443`](https://github.com/NixOS/nixpkgs/commit/ff259443704d7a20e235c1350b0684cedb9b635a) | `` linux_xanmod: 6.6.40 -> 6.6.41 ``                                                                   |
| [`7715fcde`](https://github.com/NixOS/nixpkgs/commit/7715fcde2164141c0e43b9e3561b4622ca19eca9) | `` Discord updates ``                                                                                  |
| [`47fdeac7`](https://github.com/NixOS/nixpkgs/commit/47fdeac7d515d02af1cafe3b09722b0ec54f9871) | `` linuxPackages.openafs: Patch for Linux kernel 6.10 ``                                               |
| [`c65429dd`](https://github.com/NixOS/nixpkgs/commit/c65429dd3f486938d904dcc2d6df40aaa18745db) | `` linuxPackages.openafs: Patch for Linux kernel 6.9 ``                                                |
| [`e3be8191`](https://github.com/NixOS/nixpkgs/commit/e3be819177fbd1e06583ba6bbcc20af4f59909c0) | `` android-studio-tools: init at 11076708 ``                                                           |
| [`38ad1f17`](https://github.com/NixOS/nixpkgs/commit/38ad1f17e739da4afce65718dea33b493fe0d42f) | `` nixos/proxmox-lxc: fix nixos-rebuild ``                                                             |
| [`6ab0cafe`](https://github.com/NixOS/nixpkgs/commit/6ab0cafeae6481b66c87835866b0a4265db3e3d9) | `` nixos/proxmox-lxc: fix getty start ``                                                               |
| [`f9b98282`](https://github.com/NixOS/nixpkgs/commit/f9b98282164e5c0bba0346bf1c116110b6345a14) | `` nixos/proxmox-lxc: reformat ``                                                                      |
| [`5a65ef0b`](https://github.com/NixOS/nixpkgs/commit/5a65ef0b08ad7b77a4bd108ca34e7b1d5fd5b348) | `` nixos/proxmox-lxc: fix ping in unprivileged LXCs ``                                                 |
| [`f879790b`](https://github.com/NixOS/nixpkgs/commit/f879790bc1a0341a4b0a9d0634a3c89cbcc2441d) | `` nixos/proxmox-lxc: allow importing module without activation, for used in mixed machine clusters `` |
| [`fe84f991`](https://github.com/NixOS/nixpkgs/commit/fe84f99154408d01fd275f54cdf13dd1ab7057fb) | `` nixos/proxmox-lxc: fix console access (#307163) ``                                                  |
| [`a80409c5`](https://github.com/NixOS/nixpkgs/commit/a80409c52f140fa388a14c2abd74f5202e1ee32a) | `` koboldcpp: makeWrapperArgs -> libraryPathWrapperArgs ``                                             |
| [`bab00598`](https://github.com/NixOS/nixpkgs/commit/bab005980f82d8e1ba0abdfff3ca521f37f38a56) | `` koboldcpp: lib.optionalString -> lib.optionals (cublasSupport) ``                                   |
| [`30e51422`](https://github.com/NixOS/nixpkgs/commit/30e5142260c1e06a065df9a521fd59652b255544) | `` koboldcpp: rename interface arches -> cudaArches ``                                                 |
| [`56ee801f`](https://github.com/NixOS/nixpkgs/commit/56ee801fb7eac03d93a11dfdcfdb9c69fdca0544) | `` koboldcpp: fix x86_64-darwin build ``                                                               |
| [`c7f636a1`](https://github.com/NixOS/nixpkgs/commit/c7f636a1adf0a3d173fad25299a22c0e2f9934d0) | `` koboldcpp: backport old interfaces ``                                                               |
| [`48e7a602`](https://github.com/NixOS/nixpkgs/commit/48e7a602334af4ee23fcfe1a290874b00c2cf050) | `` koboldcpp: 1.69.1 -> 1.70.1 ``                                                                      |
| [`000e2b4a`](https://github.com/NixOS/nixpkgs/commit/000e2b4a93baafb6b82c05fa9339c72f0d597e79) | `` koboldcpp: remove march, mtune and mtune ``                                                         |
| [`8285d05c`](https://github.com/NixOS/nixpkgs/commit/8285d05c551256b8cdd629b77a1683b02fb7deb8) | `` koboldcpp: add postPatch for Darwin ``                                                              |
| [`64c9d22e`](https://github.com/NixOS/nixpkgs/commit/64c9d22e514752f3d018a90fb0093da54f198b4c) | `` koboldcpp: 1.68 -> 1.69.1 ``                                                                        |
| [`14657e67`](https://github.com/NixOS/nixpkgs/commit/14657e6776aa37651af793ee0effb9a091b64dde) | `` koboldcpp: fix CUDA ``                                                                              |
| [`88d31430`](https://github.com/NixOS/nixpkgs/commit/88d31430045811231a38bb3677d48a3c296d9031) | `` koboldcpp: use python3 instead of python311 ``                                                      |
| [`1666d1a4`](https://github.com/NixOS/nixpkgs/commit/1666d1a4304f615d3db6e60710b1856f930fe34f) | `` spice-autorandr: add all linux platforms ``                                                         |
| [`0b7bf3b3`](https://github.com/NixOS/nixpkgs/commit/0b7bf3b34739aeeb79ad25199cf8e1203d25dfde) | `` consul: 1.18.2 -> 1.18.3 ``                                                                         |
| [`173448a2`](https://github.com/NixOS/nixpkgs/commit/173448a2a72b1f51c7efdd81500a583510a0ad31) | `` matrix-synapse-unwrapped: 1.110.0 -> 1.111.0 ``                                                     |
| [`122a833d`](https://github.com/NixOS/nixpkgs/commit/122a833daedc3382c483728610b7d45e84804c17) | `` qemu: 8.2.5 -> 8.2.6 ``                                                                             |
| [`7d7cf9f9`](https://github.com/NixOS/nixpkgs/commit/7d7cf9f9692f1067cc89b78941b503ffbc9e9ff2) | `` libmicrohttpd: init at 1.0.1 ``                                                                     |
| [`7a4b7a3c`](https://github.com/NixOS/nixpkgs/commit/7a4b7a3cb4d9703608668ac96aa18dafea727526) | `` python312Packages.qbittorrent-api: 2024.5.63 -> 2024.7.64 ``                                        |
| [`cd74b4bc`](https://github.com/NixOS/nixpkgs/commit/cd74b4bc91d43e7d6069f878bd773350438f8eed) | `` palemoon-bin: 33.2.0 -> 33.2.1 ``                                                                   |
| [`c34bfade`](https://github.com/NixOS/nixpkgs/commit/c34bfade688cc863af255b301f02dc2eb91202ac) | `` nixos/boot: use `--replace-fail` ``                                                                 |
| [`bc518dd3`](https://github.com/NixOS/nixpkgs/commit/bc518dd3534344a7871802a322b9244c24853216) | `` brave: 1.67.123 -> 1.67.134 ``                                                                      |
| [`a42fb7cd`](https://github.com/NixOS/nixpkgs/commit/a42fb7cdc6fb89e5f34b5b1e8c6f97b851f84434) | `` ungoogled-chromium: 126.0.6478.126-1 -> 126.0.6478.182-1 ``                                         |
| [`748cc6d3`](https://github.com/NixOS/nixpkgs/commit/748cc6d3b2251d39bcedb822de3c5f4796186cd9) | `` chromium: 126.0.6478.126 -> 126.0.6478.182 ``                                                       |
| [`315f36ba`](https://github.com/NixOS/nixpkgs/commit/315f36ba717072dc3a05a5249c9d4ca4b0c2129a) | `` chromedriver: 126.0.6478.126 -> 126.0.6478.182 ``                                                   |
| [`14fdb877`](https://github.com/NixOS/nixpkgs/commit/14fdb8777aebba6964e28b32266e4b6eaf863017) | `` firefly-iii: Streamlined derivation ``                                                              |
| [`ac644ade`](https://github.com/NixOS/nixpkgs/commit/ac644ade8dd16e456738bd673c1fe4cbf3cb2ddf) | `` wasm-tools: 1.213.0 -> 1.214.0 ``                                                                   |
| [`93dc86fd`](https://github.com/NixOS/nixpkgs/commit/93dc86fd8bd1e4b12f7328d54f3030099fef00f4) | `` wamr: 2.1.0 -> 2.1.1 ``                                                                             |
| [`de119a02`](https://github.com/NixOS/nixpkgs/commit/de119a026ee39b9153fee24812d504f68041cceb) | `` goxel: 0.14.0 -> 0.15.0 ``                                                                          |
| [`9453aa16`](https://github.com/NixOS/nixpkgs/commit/9453aa16f5184fab437aeaa00bba78620b20daa5) | `` google-chrome: 126.0.6478.126 -> 126.0.6478.182 ``                                                  |
| [`5952f328`](https://github.com/NixOS/nixpkgs/commit/5952f328f07437ab3e8063c258d67790100dccfd) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.22.0 -> 0.22.1 ``                                  |
| [`537b37fc`](https://github.com/NixOS/nixpkgs/commit/537b37fcfbbc5c09c91f86995fd5a0e68357bf48) | `` woodpecker-server: 2.6.0 -> 2.7.0 ``                                                                |
| [`8b13d6de`](https://github.com/NixOS/nixpkgs/commit/8b13d6ded1f767bdb6fcb8bc6c7f82ecf81b2679) | `` woodpecker: 2.5.0 -> 2.6.0 ``                                                                       |
| [`192641f6`](https://github.com/NixOS/nixpkgs/commit/192641f6acc02fc48ef626f8fe35cb3de612822a) | `` mysql84: 8.4.0 -> 8.4.1 ``                                                                          |
| [`0a4adcb7`](https://github.com/NixOS/nixpkgs/commit/0a4adcb7236b82621ade28a5d6bc7f457b49df3a) | `` yt-dlp: 2024.7.9 -> 2024.7.16 ``                                                                    |
| [`0207576d`](https://github.com/NixOS/nixpkgs/commit/0207576d61a8d73a62e29d61ac098b881b3376b3) | `` slskd: 0.19.5 -> 0.21.1 ``                                                                          |
| [`ede95f65`](https://github.com/NixOS/nixpkgs/commit/ede95f6502024357258822def720bda9240fb416) | `` open-fprintd: add gapps wrapper ``                                                                  |
| [`5379af0a`](https://github.com/NixOS/nixpkgs/commit/5379af0a48bc6aeac59c4641e8bbadaaa56628ae) | `` nss_latest: 3.101.1 -> 3.102 ``                                                                     |
| [`6cc10fa2`](https://github.com/NixOS/nixpkgs/commit/6cc10fa2b853a23950ca6da18050bffab86ee633) | `` linux_latest-libre: 19607 -> 19611 ``                                                               |
| [`2b8c7d6a`](https://github.com/NixOS/nixpkgs/commit/2b8c7d6afb52afca38ad1c09fe4d35caec42cc7d) | `` linux-rt_6_6: 6.6.36-rt35 -> 6.6.40-rt36 ``                                                         |
| [`e6ef80dc`](https://github.com/NixOS/nixpkgs/commit/e6ef80dcaee34bce9fed0c412fd5a8c1153c59fe) | `` linux-rt_6_1: 6.1.96-rt35 -> 6.1.99-rt36 ``                                                         |
| [`e12ba386`](https://github.com/NixOS/nixpkgs/commit/e12ba386f949a3197fd196ef6104fcf0d7b354a3) | `` linux_4_19: 4.19.317 -> 4.19.318 ``                                                                 |
| [`d5ea9f54`](https://github.com/NixOS/nixpkgs/commit/d5ea9f54c24486da0831bc7bd0c01bc7ffd1186b) | `` linux_5_4: 5.4.279 -> 5.4.280 ``                                                                    |
| [`1c000306`](https://github.com/NixOS/nixpkgs/commit/1c0003060c1c512026e83919193e72aa75643dff) | `` linux_5_10: 5.10.221 -> 5.10.222 ``                                                                 |
| [`26cc1141`](https://github.com/NixOS/nixpkgs/commit/26cc114162568fadb42d2980711c956e5fc59afd) | `` linux_5_15: 5.15.162 -> 5.15.163 ``                                                                 |
| [`099b383c`](https://github.com/NixOS/nixpkgs/commit/099b383c6aa9352f3f0904c5c7b8cb504acf8346) | `` linux_6_1: 6.1.99 -> 6.1.100 ``                                                                     |
| [`f87382f1`](https://github.com/NixOS/nixpkgs/commit/f87382f1d3caa3e3dfd2acef8a5f653368983947) | `` linux_6_6: 6.6.40 -> 6.6.41 ``                                                                      |
| [`c08d5b51`](https://github.com/NixOS/nixpkgs/commit/c08d5b513528d810870f64d8487d5b2beb1f1276) | `` linux_6_9: 6.9.9 -> 6.9.10 ``                                                                       |
| [`6fb21170`](https://github.com/NixOS/nixpkgs/commit/6fb211706a8db59bb0e035e70dc303fde0ce46c9) | `` raycast: 1.78.1 -> 1.79.0 ``                                                                        |
| [`6d9a50e8`](https://github.com/NixOS/nixpkgs/commit/6d9a50e827fde353d9329d392f6ec31e4d8e8a62) | `` element-desktop: 1.11.70 -> 1.11.71 ``                                                              |
| [`236821d9`](https://github.com/NixOS/nixpkgs/commit/236821d93c41eb21c44b44f372e4940546db7a89) | `` linux_xanmod: 6.6.39 -> 6.6.40 ``                                                                   |
| [`d6795af3`](https://github.com/NixOS/nixpkgs/commit/d6795af3f65d7567ec2257932038216d38003504) | `` python3Packages.timy: init at 0.4.2 (#290173) ``                                                    |
| [`011d5830`](https://github.com/NixOS/nixpkgs/commit/011d58309ccfae20be246f1073215f6cc96e1da1) | `` apacheHttpd: 2.4.61 -> 2.4.62 ``                                                                    |
| [`0c56e529`](https://github.com/NixOS/nixpkgs/commit/0c56e529c3832abefc96b458f66b8fcba4e24ee9) | `` glasskube: 0.11.0 -> 0.13.0 ``                                                                      |
| [`c8d4ff93`](https://github.com/NixOS/nixpkgs/commit/c8d4ff93c825d6b435be03e349051fbe983e3644) | `` wolfssl: 5.7.0 -> 5.7.2 ``                                                                          |
| [`33b45aa9`](https://github.com/NixOS/nixpkgs/commit/33b45aa9f5874393e9446cb7fbaecde8abba27d9) | `` yle-dl: 20240130 -> 20240706 ``                                                                     |
| [`262a5b04`](https://github.com/NixOS/nixpkgs/commit/262a5b04f51890bbaab4917b07ad63dd1a818c3f) | `` python3Packages.brainflow: init at 5.12.1 ``                                                        |
| [`edd1a8b8`](https://github.com/NixOS/nixpkgs/commit/edd1a8b869d3a11ced936d3fa351270fb0df2515) | `` brainflow: init at 5.12.1 ``                                                                        |
| [`f2ccdbd6`](https://github.com/NixOS/nixpkgs/commit/f2ccdbd61890c9e8f11eff2ee774b877fcf2f3a9) | `` gvfs: 1.54.1 -> 1.54.2 ``                                                                           |
| [`3282e17d`](https://github.com/NixOS/nixpkgs/commit/3282e17de45171837fef55fab6797b351d594eae) | `` gnome-keyring: 46.1 -> 46.2 ``                                                                      |
| [`65115f4d`](https://github.com/NixOS/nixpkgs/commit/65115f4da18c08f671bfdb1a7fbb69bcd8253939) | `` qt6packages.qtwayland: pull upstream fixes for crashes on screen changes ``                         |
| [`a88caba8`](https://github.com/NixOS/nixpkgs/commit/a88caba83897f398d4be2ce7c64a4804df5c2a7a) | `` python311Packages.manifestoo-core: 1.5 -> 1.6 ``                                                    |
| [`491127d8`](https://github.com/NixOS/nixpkgs/commit/491127d8f80153c1fd0344962c6044625df99721) | `` pdf4qt: 1.3.7 -> 1.4.0.0 ``                                                                         |
| [`562fe949`](https://github.com/NixOS/nixpkgs/commit/562fe949e72f35a5f9eb734cd155827111a91e91) | `` blend2d: init at 0.10 ``                                                                            |
| [`35f9f578`](https://github.com/NixOS/nixpkgs/commit/35f9f5784eb50cabac4db09c8c11035dacf36411) | `` gitlab: Un-vendor sidekiq ``                                                                        |
| [`31a77c92`](https://github.com/NixOS/nixpkgs/commit/31a77c92619a843e73d9e2d623c57bc4eca72bbf) | `` gitlab-container-registry: 4.5.0 -> 4.6.0 ``                                                        |
| [`150ba2c7`](https://github.com/NixOS/nixpkgs/commit/150ba2c70aab13f82dde4f4435879f5261fc627d) | `` gitlab: 17.1.1 -> 17.1.2 ``                                                                         |