### PR TITLE
chore(flake/nixpkgs): `a1cc729d` -> `05405724`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1721949857,
-        "narHash": "sha256-DID446r8KsmJhbCzx4el8d9SnPiE8qa6+eEQOJ40vR0=",
+        "lastModified": 1722519197,
+        "narHash": "sha256-VEdJmVU2eLFtLqCjTYJd1J7+Go8idAcZoT11IewFiRg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a1cc729dcbc31d9b0d11d86dc7436163548a9665",
+        "rev": "05405724efa137a0b899cce5ab4dde463b4fd30b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`05405724`](https://github.com/NixOS/nixpkgs/commit/05405724efa137a0b899cce5ab4dde463b4fd30b) | `` gajim: 1.9.2 -> 1.9.3 ``                                                          |
| [`8d283029`](https://github.com/NixOS/nixpkgs/commit/8d283029bb166931a03a4537ba54d68ae4fd06ad) | `` google-chrome: use `speechd` rather than `speechd-minimal` ``                     |
| [`f09849bb`](https://github.com/NixOS/nixpkgs/commit/f09849bbd3052c5b7ced220b1761ef7b8d4bd248) | `` google-chrome: use `gnome.adwaita-icon-theme` rather than `adwaita-icon-theme` `` |
| [`81b0e734`](https://github.com/NixOS/nixpkgs/commit/81b0e734f18c6722b7f6744249577ec63496eb06) | `` google-chrome: keep using addOpenGLRunpath on 24.05 ``                            |
| [`8de16175`](https://github.com/NixOS/nixpkgs/commit/8de161752b9c28fec8521db0156f974f1c86ad7d) | `` google-chrome: add gtk4 to buildInputs ``                                         |
| [`b826ac56`](https://github.com/NixOS/nixpkgs/commit/b826ac5630082986e265d8ca022fe8395f430513) | `` google-chrome: sort lists of dependencies somewhat alphabetically ``              |
| [`9e63aa48`](https://github.com/NixOS/nixpkgs/commit/9e63aa48fa686d2d91cab13b29091dc3aa871cd6) | `` google-chrome: format with `nixfmt-rfc-style` ``                                  |
| [`25d6af4c`](https://github.com/NixOS/nixpkgs/commit/25d6af4cda47e0a5a095a2c437d95cfd502c78f3) | `` google-chrome: 127.0.6533.72 -> 127.0.6533.88 ``                                  |
| [`7c81a1c4`](https://github.com/NixOS/nixpkgs/commit/7c81a1c4d117bba72f36c004d15f0ef9b26529c5) | `` epson-escpr2: 1.2.12 -> 1.2.13 ``                                                 |
| [`639d85b6`](https://github.com/NixOS/nixpkgs/commit/639d85b6324386c8b715f8aaaa05462dc0d66ad1) | `` matrix-synapse: 1.111.0 -> 1.112.0 ``                                             |
| [`9cfced93`](https://github.com/NixOS/nixpkgs/commit/9cfced9334a769339aee609419fb3a6a433f59e9) | `` koboldcpp: 1.70.1 -> 1.71.1 ``                                                    |
| [`bcf2be31`](https://github.com/NixOS/nixpkgs/commit/bcf2be31609e9cbdb5275bf6b6399de3208f60f9) | `` flyctl: 0.2.94 -> 0.2.101 ``                                                      |
| [`a784688e`](https://github.com/NixOS/nixpkgs/commit/a784688ed3a29215e485410772d8215d3b3c3ab0) | `` patroni: 3.3.0 -> 3.3.2 ``                                                        |
| [`e81f0da7`](https://github.com/NixOS/nixpkgs/commit/e81f0da7821bfffa99a1a13094ea2155a542a8e7) | `` python312Packages.hypchat: disable python >=3.12 ``                               |
| [`f1ed5c49`](https://github.com/NixOS/nixpkgs/commit/f1ed5c49cbfd74e1e7b24ca191eb504e47c7ff14) | `` discourse: update plugins ``                                                      |
| [`c7abff0f`](https://github.com/NixOS/nixpkgs/commit/c7abff0f2ede809936d2320f1eadff8a42ecfee0) | `` discourse: 3.2.4 -> 3.2.5 ``                                                      |
| [`6fd9cda8`](https://github.com/NixOS/nixpkgs/commit/6fd9cda8a54a6c7a5afb1b72e1f0c21aecea5a66) | `` remote-exec: migrate to pytest-cov-stub ``                                        |
| [`1e94f981`](https://github.com/NixOS/nixpkgs/commit/1e94f981f5872430fbb8f3297b20bcb889e1e9e2) | `` python3Packages.strt: migrate to pytest-cov-stub ``                               |
| [`1147e0b3`](https://github.com/NixOS/nixpkgs/commit/1147e0b3a1425eddb94325a5842cccdba39c0fb4) | `` todoman: migrate to pytest-cov-stub ``                                            |
| [`ba762319`](https://github.com/NixOS/nixpkgs/commit/ba762319443c22fc4f720734e0f369c8471e2672) | `` python3Packages.pytest-cov-stub: init at 1.0.0 ``                                 |
| [`c0b386aa`](https://github.com/NixOS/nixpkgs/commit/c0b386aa2c2ba147a8f6221c5490891bb1cc3951) | `` emacs.pkgs.nongnuDevelPackages: init ``                                           |
| [`e9609252`](https://github.com/NixOS/nixpkgs/commit/e9609252f85864dbf016a9a2795a5b9c490111d4) | `` emacs: format generated code for elisp packages ``                                |
| [`de77bad6`](https://github.com/NixOS/nixpkgs/commit/de77bad60520fcb44d40d39cac885f0acb42cd05) | `` emacs: do formatting in the elisp update scripts ``                               |
| [`6662c24d`](https://github.com/NixOS/nixpkgs/commit/6662c24df94ff7da2d7d799983cbb23d1fcda800) | `` koboldcpp: add separator to the prefix option of makeWrapper ``                   |
| [`55ae28b4`](https://github.com/NixOS/nixpkgs/commit/55ae28b48c9384f57069aba9e6931930c0bfe019) | `` koboldcpp: fix gpu-architecture flags from CUDA_DOCKER_ARCH ``                    |
| [`7cebda4e`](https://github.com/NixOS/nixpkgs/commit/7cebda4ea8ada698cbf5c7ad1384d0c498f8ccd7) | `` diffoscope: disable another broken test ``                                        |
| [`082b55e2`](https://github.com/NixOS/nixpkgs/commit/082b55e2cdf0f0bfeb33872ff5cb78f3826ea45b) | `` slack: 4.38.125 -> 4.39.90 ``                                                     |
| [`04306b4c`](https://github.com/NixOS/nixpkgs/commit/04306b4cd3f203f2c7a9720a06668366520cb72b) | `` slack: fix update script ``                                                       |
| [`dd03ba5b`](https://github.com/NixOS/nixpkgs/commit/dd03ba5b4863e198104ece27121882969d16c3af) | `` tlrc: 1.9.2 -> 1.9.3 ``                                                           |
| [`f1fbf61d`](https://github.com/NixOS/nixpkgs/commit/f1fbf61d0bab897e7b8bc2ab0671448b36e28e68) | `` gnome-software: add glib-networking to fix screenshots ``                         |
| [`1051d120`](https://github.com/NixOS/nixpkgs/commit/1051d120f54b3f0df830dac92241d5e67b020e38) | `` bs-platform: remove ``                                                            |
| [`a301bd02`](https://github.com/NixOS/nixpkgs/commit/a301bd028f237504819158efdc99b39d003de05f) | `` mdbook-i18n-helpers: 0.3.4 -> 0.3.5 ``                                            |
| [`b9bd1669`](https://github.com/NixOS/nixpkgs/commit/b9bd1669275b64b81c44d0b772b7a9e76eff1f65) | `` llvm: Fix compiler-rt missing sanitizers when using useLLVM ``                    |
| [`333a3311`](https://github.com/NixOS/nixpkgs/commit/333a3311cda9833ffd4b668aa06bc30874a3c82a) | `` docker_25: 25.0.5 -> 25.0.6 ``                                                    |
| [`2cf7af75`](https://github.com/NixOS/nixpkgs/commit/2cf7af75a82a13cda0510a2fde05c42a6fc52489) | `` electron-chromedriver_29: 29.4.4 -> 29.4.5 ``                                     |
| [`46e8a0a5`](https://github.com/NixOS/nixpkgs/commit/46e8a0a537e5f136da72945f0885fae0914f2480) | `` electron-source.electron_29: 29.4.4 -> 29.4.5 ``                                  |
| [`3d558a44`](https://github.com/NixOS/nixpkgs/commit/3d558a447431859e51d0049b457be96ff6b7f1a8) | `` electron_29-bin: 29.4.4 -> 29.4.5 ``                                              |
| [`27c0458a`](https://github.com/NixOS/nixpkgs/commit/27c0458a6eedd10b04001b03862af14c8992917e) | `` docker_26: 26.1.4 -> 26.1.5 ``                                                    |
| [`7db3d777`](https://github.com/NixOS/nixpkgs/commit/7db3d777f0fb4227e24082a35ad19c24de1ff5e2) | `` docker_25: 25.0.5 -> 25.0.6 ``                                                    |
| [`4259fe95`](https://github.com/NixOS/nixpkgs/commit/4259fe95e724ddda48a6369d69706cb5dfe27b7e) | `` docker_24: add known CVEs ``                                                      |
| [`dbef07c3`](https://github.com/NixOS/nixpkgs/commit/dbef07c3e596446ecd013aacc9f6d9651c799d75) | `` docker: move default from 24.x to 25.x ``                                         |
| [`090a65e3`](https://github.com/NixOS/nixpkgs/commit/090a65e3b00c7c5c0accb8383a02182e06ccdadc) | `` vscode-extensions.ms-dotnettools.vscodeintellicode-csharp: init 2.1.11 ``         |
| [`63b5574b`](https://github.com/NixOS/nixpkgs/commit/63b5574b1ccfcf5f8dc69ba0b26787a5bab7e7f0) | `` vscode-extensions.ms-dotnettools.vscode-dotnet-runtime: init 2.1.1 ``             |
| [`8fdf650e`](https://github.com/NixOS/nixpkgs/commit/8fdf650e30d3709362780246a0631b9643ff6dcd) | `` vscode-extensions.csharpier.csharpier-vscode: init 1.7.3 ``                       |
| [`da652d5a`](https://github.com/NixOS/nixpkgs/commit/da652d5ac0a5ebcb65d8f56ed6119f127bb8135e) | `` sapling: 0.2.202401116 -> 0.2.20240718 ``                                         |
| [`f29abfc0`](https://github.com/NixOS/nixpkgs/commit/f29abfc008b7eb9f979bec1e09fdd4e497c5333c) | `` terraspace: 2.2.8 -> 2.2.17 ``                                                    |
| [`99e24c60`](https://github.com/NixOS/nixpkgs/commit/99e24c606aba1531c68b65ffbf081d963c0d2f05) | `` terraspace: remove version from Gemfile ``                                        |
| [`28d35856`](https://github.com/NixOS/nixpkgs/commit/28d3585633bf38f9c02e5380d6a22dc6e46a5aba) | `` google-chrome: add changelog link to make it easier for reviewers ``              |
| [`43a5cfd3`](https://github.com/NixOS/nixpkgs/commit/43a5cfd30b3ceee96ff8ff2860b1b8a38679a9d2) | `` google-chrome: 126.0.6478.182 -> 127.0.6533.72 ``                                 |
| [`95c32d7f`](https://github.com/NixOS/nixpkgs/commit/95c32d7f4ca404d61dda341787d527508a1023cd) | `` ungoogled-chromium: 126.0.6478.182-1 -> 127.0.6533.72-1 ``                        |
| [`16bb67ec`](https://github.com/NixOS/nixpkgs/commit/16bb67ec64fa94bdc20079e33108d168b03e6dee) | `` virtualisation/{docker,podman}: update nvidia-ctk warning ``                      |
| [`88930a59`](https://github.com/NixOS/nixpkgs/commit/88930a59255e55b6a9211dfe45d6c0a22f8e9402) | `` linuxKernel.kernels.linux_zen: 6.9.8-lqx1 -> 6.9.11-lqx1 ``                       |
| [`086f74d7`](https://github.com/NixOS/nixpkgs/commit/086f74d77acaa02565095b3f4fbe2e6af5eebc59) | `` linuxKernel.kernels.linux_zen: 6.9.8-zen1 -> 6.10.1-zen1 ``                       |
| [`440ac0a1`](https://github.com/NixOS/nixpkgs/commit/440ac0a16e122001c3c0777b56cd076c672cb913) | `` linux-rt_5_15: 5.15.160-rt77 -> 5.15.163-rt78 ``                                  |
| [`2d006c92`](https://github.com/NixOS/nixpkgs/commit/2d006c929c6e2252c77901f461302aa5881307f7) | `` linux_4_19: 4.19.318 -> 4.19.319 ``                                               |
| [`4b1817d0`](https://github.com/NixOS/nixpkgs/commit/4b1817d052658e93fed95170160a7e71d33466b3) | `` linux_5_4: 5.4.280 -> 5.4.281 ``                                                  |
| [`d4b54962`](https://github.com/NixOS/nixpkgs/commit/d4b54962fad72f7fb71a195b82dd0e9dd10d8c4b) | `` linux_5_10: 5.10.222 -> 5.10.223 ``                                               |
| [`e1b938ec`](https://github.com/NixOS/nixpkgs/commit/e1b938ecbc01954a728744fd87e1768bcf75aade) | `` linux_5_15: 5.15.163 -> 5.15.164 ``                                               |
| [`ebcfee0b`](https://github.com/NixOS/nixpkgs/commit/ebcfee0b9352d624bc816582201f79b42cfdc0b1) | `` linux_6_1: 6.1.101 -> 6.1.102 ``                                                  |
| [`6ea14e2b`](https://github.com/NixOS/nixpkgs/commit/6ea14e2b0d9548ef99279bc66619fc6dc4b16ce4) | `` linux_6_6: 6.6.42 -> 6.6.43 ``                                                    |
| [`67253656`](https://github.com/NixOS/nixpkgs/commit/6725365645bc4ed1b7d3d7982ff79416c0cdf893) | `` linux_6_9: 6.9.11 -> 6.9.12 ``                                                    |
| [`c461903f`](https://github.com/NixOS/nixpkgs/commit/c461903fdc970814eca916167e325264d38af4b8) | `` linux_6_10: 6.10.1 -> 6.10.2 ``                                                   |
| [`5e5b9e70`](https://github.com/NixOS/nixpkgs/commit/5e5b9e70aa3623fe70ba3d92ec79bfdfd64a3630) | `` linux/update-mainline: always pick the latest kernel on a branch ``               |
| [`d24055bd`](https://github.com/NixOS/nixpkgs/commit/d24055bd373386f0bcc0aa0e2b4c5fb2483da620) | `` nixos/plasma6: enable programs.kde-pim by default ``                              |
| [`e6dacc09`](https://github.com/NixOS/nixpkgs/commit/e6dacc093c7f22b15a65620168a1b9ed911ddbdc) | `` programs/kde-pim: init ``                                                         |
| [`8f987041`](https://github.com/NixOS/nixpkgs/commit/8f987041c3f496eb7b88f9ff6b98f899f4b38e04) | `` argocd: 2.11.2 -> 2.11.3 ``                                                       |
| [`18e7c0d0`](https://github.com/NixOS/nixpkgs/commit/18e7c0d06e9e63b8af14ab6a78d0ad8d19d0021e) | `` argocd: 2.11.1 -> 2.11.2 ``                                                       |
| [`5a83705f`](https://github.com/NixOS/nixpkgs/commit/5a83705f4e39cfe37682c9fd1afb25f6bd8189a5) | `` argocd: 2.11.0 -> 2.11.1 ``                                                       |
| [`28b1d46b`](https://github.com/NixOS/nixpkgs/commit/28b1d46b3d048122108132e237e7d7a0fbd62d61) | `` discord-stable: 0.0.60 -> 0.0.61 ``                                               |
| [`23631bc3`](https://github.com/NixOS/nixpkgs/commit/23631bc39682770a9a2205d0518f83e5b5d4655c) | `` chromium,chromedriver: 126.0.6478.182 -> 127.0.6533.72 ``                         |
| [`3d7c8f70`](https://github.com/NixOS/nixpkgs/commit/3d7c8f701b6c78dedc448bc030b6fbbbeae4b275) | `` chromium: prepare for M127 ``                                                     |
| [`8811b0d1`](https://github.com/NixOS/nixpkgs/commit/8811b0d18dcb765530c31a245ba49eb4d43c99a9) | `` cri-o-unwrapped: 1.30.0 -> 1.30.1 ``                                              |
| [`d28e0cd4`](https://github.com/NixOS/nixpkgs/commit/d28e0cd4322f58d951584abb9a063a15c14c4714) | `` python311Packages.wagtail: 6.0.2 -> 6.0.5 ``                                      |
| [`7c89876f`](https://github.com/NixOS/nixpkgs/commit/7c89876f0aedf3caff1665a1375554315f44b0e4) | `` libvpx_1_8: mark with knownVulnerabilities ``                                     |
| [`780431f7`](https://github.com/NixOS/nixpkgs/commit/780431f72937db8059f7a2e61c39bc04ecb02039) | `` cargo-tally: 1.0.47 -> 1.0.48 ``                                                  |
| [`43b0bf9e`](https://github.com/NixOS/nixpkgs/commit/43b0bf9e2bd139fb5bc9b9d3f72a8524e7b26af0) | `` cargo-component: 0.13.2 -> 0.14.0 ``                                              |
| [`b8e31dda`](https://github.com/NixOS/nixpkgs/commit/b8e31dda0463e3a67e68f535cd20a003250f33ed) | `` cargo-deny: 0.14.24 -> 0.15.0 ``                                                  |
| [`1fd44b72`](https://github.com/NixOS/nixpkgs/commit/1fd44b72eef1ee0d8972186f60f92d9b00f85968) | `` cargo-workspaces: 0.3.2 -> 0.3.5 ``                                               |
| [`c27d5cae`](https://github.com/NixOS/nixpkgs/commit/c27d5cae76214edd928f288dbf6bbbf3c591e8b5) | `` cargo-workspaces: 0.3.1 -> 0.3.2 ``                                               |
| [`09c5c670`](https://github.com/NixOS/nixpkgs/commit/09c5c6705aa5a9c88694b85b48ffc373f85ca771) | `` cargo-llvm-cov: 0.6.10 -> 0.6.11 ``                                               |
| [`4f4f51f8`](https://github.com/NixOS/nixpkgs/commit/4f4f51f85c37ba92123f732b2c183e32f132b2ae) | `` cargo-hack: 0.6.29 -> 0.6.30 ``                                                   |
| [`4a1831af`](https://github.com/NixOS/nixpkgs/commit/4a1831af39b501eb697d0f86549cef790496668f) | `` cargo-hack: 0.6.28 -> 0.6.29 ``                                                   |
| [`a1bc66a6`](https://github.com/NixOS/nixpkgs/commit/a1bc66a6f7dbb69769999e54af072b1f966bbaf1) | `` cargo-udeps: 0.1.47 -> 0.1.49 ``                                                  |
| [`dabc41be`](https://github.com/NixOS/nixpkgs/commit/dabc41be54b18a0c26d222eb8d978d4e9926015a) | `` cargo-dist: 0.18.0 -> 0.19.1 ``                                                   |
| [`605c41b8`](https://github.com/NixOS/nixpkgs/commit/605c41b8e6971bae7f91d6218ec563e4969072e2) | `` cargo-dist: 0.17.0 -> 0.18.0 ``                                                   |
| [`d0b81334`](https://github.com/NixOS/nixpkgs/commit/d0b813342dc62d2ed50ff5865c1783e6ae00cd9c) | `` cargo-dist: 0.16.0 -> 0.17.0 ``                                                   |
| [`31d8a580`](https://github.com/NixOS/nixpkgs/commit/31d8a580e8209caa7743353b4b5d2bdf62609f1f) | `` cargo-zigbuild: 0.19.0 -> 0.19.1 ``                                               |
| [`9ead5c9a`](https://github.com/NixOS/nixpkgs/commit/9ead5c9a35df0528937a2032a5fdd5656a615572) | `` cargo-zigbuild: use zig from buildPackages ``                                     |
| [`5f88d437`](https://github.com/NixOS/nixpkgs/commit/5f88d43710162c84aa08369502d4362d6ba69b77) | `` cargo-zigbuild: 0.18.4 -> 0.19.0 ``                                               |
| [`b09f0315`](https://github.com/NixOS/nixpkgs/commit/b09f03157f6699b1ab378bfbf73d14518e7a8cc2) | `` cargo-tauri: 1.6.8 -> 1.7.1 ``                                                    |
| [`f9139838`](https://github.com/NixOS/nixpkgs/commit/f9139838f4870d65c48d54368592e9a029674064) | `` cargo-semver-checks: 0.32.0 -> 0.33.0 ``                                          |
| [`53a9aff5`](https://github.com/NixOS/nixpkgs/commit/53a9aff55b536764e99ce0a31f53c5153b8fd7f4) | `` linux_xanmod_latest: 6.9.10 -> 6.9.11 ``                                          |
| [`26373dc9`](https://github.com/NixOS/nixpkgs/commit/26373dc967684d9308d55d5012c09d6a3e145526) | `` linux_xanmod: 6.6.41 -> 6.6.42 ``                                                 |
| [`669a5032`](https://github.com/NixOS/nixpkgs/commit/669a5032b76672c1f1ffaaa2fef711ad756e4ab1) | `` sngrep: 1.8.1 -> 1.8.2 ``                                                         |
| [`e2e186db`](https://github.com/NixOS/nixpkgs/commit/e2e186db0aa843f3d9108a51020e529fef76458c) | `` discord-development: 0.0.23 -> 0.0.24 ``                                          |
| [`baef26a4`](https://github.com/NixOS/nixpkgs/commit/baef26a49d242cfa9e933c7153e366d7e790a27a) | `` grafana: 10.4.5 -> 10.4.6 ``                                                      |
| [`40bc078f`](https://github.com/NixOS/nixpkgs/commit/40bc078f67b18eaae97511d6d270f38bdb3c174d) | `` electron-chromedriver_30: 30.2.0 -> 30.3.1 ``                                     |
| [`e5685891`](https://github.com/NixOS/nixpkgs/commit/e5685891976de2e17d1727138b9965b6030866f1) | `` electron-source.electron_30: 30.2.0 -> 30.3.1 ``                                  |
| [`191ead6b`](https://github.com/NixOS/nixpkgs/commit/191ead6b09e424dca8fb8a81b979820efabe588a) | `` electron_30-bin: 30.2.0 -> 30.3.1 ``                                              |
| [`0987748f`](https://github.com/NixOS/nixpkgs/commit/0987748f66cf8e36d3a36e9db3338b442e75960f) | `` docker_27: 27.0.3 -> 27.1.1 ``                                                    |
| [`28c3f3e2`](https://github.com/NixOS/nixpkgs/commit/28c3f3e2991a4bffc3c7a9f1407d0f5c73e7ce9e) | `` firefox-bin-unwrapped: 128.0.2 -> 128.0.3 ``                                      |
| [`776e437c`](https://github.com/NixOS/nixpkgs/commit/776e437c0cdd9cfc5fbc799b6cb9e2e2ca6ce14f) | `` firefox-unwrapped: 128.0.2 -> 128.0.3 ``                                          |
| [`e2beea21`](https://github.com/NixOS/nixpkgs/commit/e2beea21b79cdd9f05961570b9c11ba43232dbfb) | `` chromium: fix `update.py` python3.12 compat ``                                    |
| [`9a769349`](https://github.com/NixOS/nixpkgs/commit/9a7693491c8674b1060fa07b9d2a618b96f1d792) | `` magnetico: unstable-2022-08-10 -> 0.12.1 ``                                       |
| [`ca9200e8`](https://github.com/NixOS/nixpkgs/commit/ca9200e8d4496f642443d904b219e36a42597b8d) | `` uwsm: init at 0.17.0 ``                                                           |
| [`ea6e59a0`](https://github.com/NixOS/nixpkgs/commit/ea6e59a0bab5a2b50547d20ac6c60554b50656ec) | `` python312Packages.scrapy: 2.11.1 -> 2.11.2 ``                                     |
| [`899ba32f`](https://github.com/NixOS/nixpkgs/commit/899ba32f656a46d323c061f0972a8f219622aa3f) | `` thunderbirdPackages.thunderbird-128: 128.0esr -> 128.0.1esr ``                    |
| [`0910ecf5`](https://github.com/NixOS/nixpkgs/commit/0910ecf5a7fc15be50452f08abe1b35a73db74da) | `` yt-dlp: 2024.7.16 -> 2024.7.25 ``                                                 |
| [`1410fc00`](https://github.com/NixOS/nixpkgs/commit/1410fc00f7f4ba3244815a1bc3aab4e1214537b4) | `` nixVersions.nix_2_23: init at 2.23.3 ``                                           |
| [`500dc4e3`](https://github.com/NixOS/nixpkgs/commit/500dc4e3d10414ccbc30f8ab2b1ae7ffc0d713cb) | `` tracker-miners: fix store permissions ``                                          |
| [`57684917`](https://github.com/NixOS/nixpkgs/commit/576849170c64b2f04f4b245fb34057bd30c116e5) | `` linuxKernel.packages.hpuefi-mod: init at 3.05 ``                                  |
| [`66e4826a`](https://github.com/NixOS/nixpkgs/commit/66e4826a4efcf66f97f670dea011e702b923c4e8) | `` warp-terminal: 0.2024.07.09.08.01.stable_00 -> 0.2024.07.16.08.02.stable_03 ``    |
| [`fc6882eb`](https://github.com/NixOS/nixpkgs/commit/fc6882eb3c3ad3e7729a35fb2bc7e9474e936681) | `` libvirt: add patch for CVE-2024-4418 ``                                           |
| [`1f64b574`](https://github.com/NixOS/nixpkgs/commit/1f64b5746d3160f751a338cbf6d20747993fd52c) | `` gnucash: 5.6 -> 5.8 ``                                                            |
| [`aaef17c4`](https://github.com/NixOS/nixpkgs/commit/aaef17c4337d935b960c68d019a8d78fb125db15) | `` jetbrains.{idea,pycharm}-community-src: 2023.3.2 -> 2024.1.3 ``                   |
| [`a081f156`](https://github.com/NixOS/nixpkgs/commit/a081f156ed1f35e2cabfb9edb5ddf92cb6eb9c28) | `` python311Packages.trfl: mark as broken ``                                         |
| [`05db9335`](https://github.com/NixOS/nixpkgs/commit/05db9335d934d243a24b0583f4d301bd457e8d5f) | `` python311Packages.mhcflurry: 2.1.0 -> 2.1.1 + mark as broken ``                   |
| [`79e4733b`](https://github.com/NixOS/nixpkgs/commit/79e4733b5d3d53d6ca194df7af40552a17885cd4) | `` python311Packages.wandb: disable tests that depend on keras ``                    |
| [`9b5c2585`](https://github.com/NixOS/nixpkgs/commit/9b5c2585f7943ddad97dde9287d94a140ab39ae5) | `` python311Packages.keras: 3.2.1 -> 3.3.3 ``                                        |
| [`76a2517d`](https://github.com/NixOS/nixpkgs/commit/76a2517d52ced44dddc171f3701d0288643a8117) | `` python311Packages.namex: init at 0.0.8 ``                                         |