### PR TITLE
chore(flake/nix-ld-rs): `2f1fe38b` -> `ad90f105`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -286,11 +286,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721394956,
-        "narHash": "sha256-VnayJVKngasaNNiMlBhkeA//+V9EpEuT/mkOsFUbFDg=",
+        "lastModified": 1722634972,
+        "narHash": "sha256-34OfOf0A0v0T4iWuZ2hI6YIZedwXkPsGtNfbac3fR0s=",
         "owner": "nix-community",
         "repo": "nix-ld-rs",
-        "rev": "2f1fe38bc69d2400652e0848d9d2ce2955a39cf6",
+        "rev": "ad90f105e8fbaa0b0c87f464b862008598a903ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                  |
| -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`ad90f105`](https://github.com/nix-community/nix-ld-rs/commit/ad90f105e8fbaa0b0c87f464b862008598a903ea) | `` chore(deps): update rust crate tempfile to v3.11.0 `` |
| [`178b100f`](https://github.com/nix-community/nix-ld-rs/commit/178b100f4dda6b1280e9619270009fc8c0938e73) | `` chore(deps): update rust crate cc to v1.1.7 ``        |