### PR TITLE
chore(flake/nixpkgs): `05405724` -> `a633d89c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -359,11 +359,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1722519197,
-        "narHash": "sha256-VEdJmVU2eLFtLqCjTYJd1J7+Go8idAcZoT11IewFiRg=",
+        "lastModified": 1722651103,
+        "narHash": "sha256-IRiJA0NVAoyaZeKZluwfb2DoTpBAj+FLI0KfybBeDU0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "05405724efa137a0b899cce5ab4dde463b4fd30b",
+        "rev": "a633d89c6dc9a2a8aae11813a62d7c58b2c0cc51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`1c407d20`](https://github.com/NixOS/nixpkgs/commit/1c407d20c6c4522b1d78e31842e9628e448bf0ed) | `` overrideSDK: handle propagated lists of inputs ``                   |
| [`9a0987f5`](https://github.com/NixOS/nixpkgs/commit/9a0987f50b649372eddab6b167453e72d5601ed2) | `` linux_xanmod_latest: 6.9.11 -> 6.9.12 ``                            |
| [`d354c6dc`](https://github.com/NixOS/nixpkgs/commit/d354c6dccf5da37933c7d03f115f4dd37c60ca07) | `` linux_xanmod: 6.6.42 -> 6.6.43 ``                                   |
| [`ba7027b7`](https://github.com/NixOS/nixpkgs/commit/ba7027b7b9e9cebb85146fd79ef58f688dfc9976) | `` restic-integrity: 1.2.1 -> 1.2.2 ``                                 |
| [`0bfd3491`](https://github.com/NixOS/nixpkgs/commit/0bfd3491dd9c4dbb171e903f684f7f89b2f01e08) | `` restic-integrity: update src to fetch from git.nwex.de ``           |
| [`ade13d2b`](https://github.com/NixOS/nixpkgs/commit/ade13d2bcdb9df61ed79a7f99a655b000620647e) | `` nextcloud-notify_push: 0.6.12 -> 0.7.0 ``                           |
| [`6b4cef93`](https://github.com/NixOS/nixpkgs/commit/6b4cef93c58dca81aa16ae625bb9c1e792f7e1bc) | `` nextcloudPackages: update ``                                        |
| [`3ce7059e`](https://github.com/NixOS/nixpkgs/commit/3ce7059e8297c42c364a5c1cbf9dce39c9302db4) | `` nc4nix: 0-unstable-2024-03-01 -> 0-unstable-2024-08-01 ``           |
| [`688d0d21`](https://github.com/NixOS/nixpkgs/commit/688d0d21f51e8febfea51cd500e5c7606f97c499) | `` imagemagick: 7.1.1-35 -> 7.1.1-36 ``                                |
| [`a918b467`](https://github.com/NixOS/nixpkgs/commit/a918b4678b198ba93e7efa651599468c60852562) | `` element-desktop: 1.11.71 -> 1.11.72 ``                              |
| [`7e09ae8e`](https://github.com/NixOS/nixpkgs/commit/7e09ae8ed52b2a6858d247207193e07f5b04048a) | `` ungoogled-chromium: 127.0.6533.72-1 -> 127.0.6533.88-1 ``           |
| [`1770ecd7`](https://github.com/NixOS/nixpkgs/commit/1770ecd7b818194c59a5ab5b23246797a9522180) | `` chromedriver,chromium: 127.0.6533.72 -> 127.0.6533.88 ``            |
| [`bad05fb0`](https://github.com/NixOS/nixpkgs/commit/bad05fb02cbc07be65bc060e7a5058c6b853b351) | `` nbxmpp: 5.0.1 -> 5.0.3 ``                                           |
| [`d924c79a`](https://github.com/NixOS/nixpkgs/commit/d924c79a8eb9fa7d81e6b3b8927c2bf24dc361a2) | `` forgejo: 7.0.5 -> 7.0.6 ``                                          |
| [`6d2033ee`](https://github.com/NixOS/nixpkgs/commit/6d2033ee8cfdff04343601f361aed024b9e8dc4f) | `` haskellPackages.avro: unbreak with upstream patch ``                |
| [`3160eac7`](https://github.com/NixOS/nixpkgs/commit/3160eac7951e74cc3fd623f0f804751398d335d9) | `` thunderbird-bin-unwrapped: 115.10.1 -> 115.13.0 ``                  |
| [`a76fc1ab`](https://github.com/NixOS/nixpkgs/commit/a76fc1abb599d58beb5508d7e1ac71e129b38d39) | `` signal-desktop-beta: 7.17.0-beta.1 ->7.18.0-beta.1 ``               |
| [`bca896cc`](https://github.com/NixOS/nixpkgs/commit/bca896ccffc597bbf41cffee0316c7b3318f7bc3) | `` signal-desktop: 7.16.0 -> 7.17.0 ``                                 |
| [`9fa985d9`](https://github.com/NixOS/nixpkgs/commit/9fa985d96444a8fbe5f7ff4f2ed83c6886117994) | `` skypeforlinux, spotify: remove snap.yaml file ``                    |
| [`ab2cde66`](https://github.com/NixOS/nixpkgs/commit/ab2cde66dace47cd0a423b9ed7f379facfe04d4e) | `` nightfox-gtk-theme: unstable-2023-05-28 -> 0-unstable-2024-06-27 `` |
| [`2907d64b`](https://github.com/NixOS/nixpkgs/commit/2907d64b6d457c2693fa476f1c39ec4d00226bf5) | `` skypeforlinux: add updateScript ``                                  |
| [`555524f7`](https://github.com/NixOS/nixpkgs/commit/555524f746640b6ce604872ec085446059fe263b) | `` skypeforlinux: 8.110.76.107 -> 8.119.0.201 ``                       |
| [`286691b6`](https://github.com/NixOS/nixpkgs/commit/286691b6f23eabe143419b6053c1b0cc52739837) | `` skypeforlinux: nixfmt ``                                            |
| [`72e7129d`](https://github.com/NixOS/nixpkgs/commit/72e7129dca6de6171dd0cc8e86079d8e2a9d8afe) | `` skypeforlinux: move to pkgs/by-name ``                              |
| [`2ca340bf`](https://github.com/NixOS/nixpkgs/commit/2ca340bf20d26ec605156ff2140a287314465996) | `` haskell.compiler.*: calculate tool path using common function ``    |