### PR TITLE
chore(flake/nixpkgs): `a633d89c` -> `883180e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -359,11 +359,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1722651103,
-        "narHash": "sha256-IRiJA0NVAoyaZeKZluwfb2DoTpBAj+FLI0KfybBeDU0=",
+        "lastModified": 1722869614,
+        "narHash": "sha256-7ojM1KSk3mzutD7SkrdSflHXEujPvW1u7QuqWoTLXQU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a633d89c6dc9a2a8aae11813a62d7c58b2c0cc51",
+        "rev": "883180e6550c1723395a3a342f830bfc5c371f6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`146b61c4`](https://github.com/NixOS/nixpkgs/commit/146b61c4152fdab934cc67977b2d95e344db2997) | `` gowall: init at 0.1.5 ``                                                           |
| [`8b4b8ea9`](https://github.com/NixOS/nixpkgs/commit/8b4b8ea9cf3b784ce96ed090809fc0259d72120a) | `` nixos/release-small: stop building amazon image ``                                 |
| [`8c12033b`](https://github.com/NixOS/nixpkgs/commit/8c12033b1ef1ac4dd94e30601bedaa1345c735e9) | `` grafana-loki: add new subpackage ``                                                |
| [`e378a918`](https://github.com/NixOS/nixpkgs/commit/e378a9181dd288530110466017f762cdeacddf3c) | `` grafana-loki: 3.0.0 -> 3.1.0 ``                                                    |
| [`edc7e3ef`](https://github.com/NixOS/nixpkgs/commit/edc7e3efbf6b7b5187c072fc23e4df8251a7973a) | `` miniflux: fix panic on youtube channel feed discovery ``                           |
| [`f6535665`](https://github.com/NixOS/nixpkgs/commit/f6535665d861d2df5c6afce5f59a01a11658a4b9) | `` [Backport release-24.05] veilid: 0.3.3 -> 0.3.4 ``                                 |
| [`15b52597`](https://github.com/NixOS/nixpkgs/commit/15b5259787a70edd84ec67a288e6fca83da3adde) | `` linuxManualConfig: remove "$src is not a directory" logspam ``                     |
| [`fea54e56`](https://github.com/NixOS/nixpkgs/commit/fea54e56e7c33446364dc5ed078d50e0e14d6d49) | `` nixos/deconz: mention RaspBee hardware ``                                          |
| [`c35006b9`](https://github.com/NixOS/nixpkgs/commit/c35006b99c025c4cc2de259eb7c2661cb3708b76) | `` nixos/deconz: update URL to hardware products ``                                   |
| [`b4f52423`](https://github.com/NixOS/nixpkgs/commit/b4f52423959ba7cf97fb095e028361b1f5cd5f9f) | `` laurel: fix compiling on aarch64-linux ``                                          |
| [`e3f68ec7`](https://github.com/NixOS/nixpkgs/commit/e3f68ec7ec778f1fc90782143b71cd2385ba0a11) | `` laurel: 0.6.2 -> 0.6.3 ``                                                          |
| [`ba6744f5`](https://github.com/NixOS/nixpkgs/commit/ba6744f5109fe965924f692bb1263e169a32b1ad) | `` discord: updates (#332018) ``                                                      |
| [`9261de0d`](https://github.com/NixOS/nixpkgs/commit/9261de0d4e5d2526e1d0710c81f5b01672ea1f37) | `` goxel: 0.15.0 -> 0.15.1 ``                                                         |
| [`af302448`](https://github.com/NixOS/nixpkgs/commit/af302448820f0f9ade5f4e581d886b42bb67a895) | `` signal-desktop-beta: 7.18.0-beta1 -> 7.19.0-beta1 ``                               |
| [`2ae80141`](https://github.com/NixOS/nixpkgs/commit/2ae80141911b469a4e9b4abcf778ed7157638c9a) | `` brave: 1.67.134 -> 1.68.134 ``                                                     |
| [`4cccbb8f`](https://github.com/NixOS/nixpkgs/commit/4cccbb8fdb3e69634715fb8f54485618f0acc709) | `` signal-desktop: 7.17.0 -> 7.18.0 ``                                                |
| [`e9d5b706`](https://github.com/NixOS/nixpkgs/commit/e9d5b706fd14fb0250eaee8bc17453eb8af94c6a) | `` borgbackup: 1.2.8 -> 1.4.0 ``                                                      |
| [`2f27f57a`](https://github.com/NixOS/nixpkgs/commit/2f27f57ad8957959e0d6e83cda07cc75acdf074a) | `` switcheroo: add missing imagemagick dependency ``                                  |
| [`71bc8726`](https://github.com/NixOS/nixpkgs/commit/71bc87260cff4aad71e402f996a768f94faf0587) | `` linux-rt_5_10: 5.10.221-rt113 -> 5.10.222-rt114 ``                                 |
| [`e2fbe78c`](https://github.com/NixOS/nixpkgs/commit/e2fbe78c529cdeb1e6a99aaa23b30b3ebeea9a3b) | `` linux_6_1: 6.1.102 -> 6.1.103 ``                                                   |
| [`ae9f7032`](https://github.com/NixOS/nixpkgs/commit/ae9f70329e15533c92f558b559b155425533820e) | `` linux_6_6: 6.6.43 -> 6.6.44 ``                                                     |
| [`3b831e65`](https://github.com/NixOS/nixpkgs/commit/3b831e65232b20a7a324b97e7e6e5a89da90671a) | `` linux_6_10: 6.10.2 -> 6.10.3 ``                                                    |
| [`80ef8454`](https://github.com/NixOS/nixpkgs/commit/80ef8454d5f117c9de83560153835218d1ba8871) | `` freetube: 0.21.2 -> 0.21.3 ``                                                      |
| [`2bfb8721`](https://github.com/NixOS/nixpkgs/commit/2bfb8721a32366b66c5371b41d1eb4b549fd0ee0) | `` freetube: 0.21.1 -> 0.21.2 ``                                                      |
| [`116cd8da`](https://github.com/NixOS/nixpkgs/commit/116cd8da9cd0c3a995423e2ec56c0c6a1189fd2b) | `` freetube: 0.21.0 -> 0.21.1 ``                                                      |
| [`a505ebc8`](https://github.com/NixOS/nixpkgs/commit/a505ebc824f38815c047aa00d079ea2febeef307) | `` freetube: 0.20.0 -> 0.21.0 ``                                                      |
| [`03b63017`](https://github.com/NixOS/nixpkgs/commit/03b63017ed9d0d7b3dd5b29bb61a0b561bef5849) | `` nixos/flatpak: add package option ``                                               |
| [`be2df9d7`](https://github.com/NixOS/nixpkgs/commit/be2df9d728c8c193aace15d08ea0abe547f50741) | `` undmg: 1.1.0 -> 1.1.0-unstable-2024-08-02 ``                                       |
| [`041fcb2e`](https://github.com/NixOS/nixpkgs/commit/041fcb2ee1ef97fb5011c6e0bcf0038b9c66c01e) | `` undmg: refactor meta ``                                                            |
| [`6c0d3318`](https://github.com/NixOS/nixpkgs/commit/6c0d3318c54a99306215592ee2073c4f6214adcb) | `` undmg: format ``                                                                   |
| [`704b2f66`](https://github.com/NixOS/nixpkgs/commit/704b2f6673ab7e8b4bfa001b665b69cbb26dc9f0) | `` yggdrasil: 0.5.5 -> 0.5.6 ``                                                       |
| [`c51998a2`](https://github.com/NixOS/nixpkgs/commit/c51998a29b13ca855dde13ada9d1fab0f88519c1) | `` asterisk: 20.8.1 -> 20.9.0 ``                                                      |
| [`2dde1244`](https://github.com/NixOS/nixpkgs/commit/2dde124486328d93f3df0a6202a71a2cc77ec632) | `` wavebox: 10.124.17-2 -> 10.127.10-2 (#324822) ``                                   |
| [`90153e72`](https://github.com/NixOS/nixpkgs/commit/90153e72171c3206c6ced3786eeef928eb7560fe) | `` spotify: 1.2.40.599.g606b7f29 -> 1.2.42.290.g242057a2 ``                           |
| [`e3d45c64`](https://github.com/NixOS/nixpkgs/commit/e3d45c647f16704413d2720a6e73d755dedb7053) | `` yt-dlp: 2024.7.25 -> 2024.8.1 ``                                                   |
| [`bc45d784`](https://github.com/NixOS/nixpkgs/commit/bc45d784dbf5763c940701a838b41eb31490a020) | `` vscode: 1.91.1 -> 1.92.0 ``                                                        |
| [`a02ad555`](https://github.com/NixOS/nixpkgs/commit/a02ad5557fe1e528eacc2c2d77c8c70aa65e8e8b) | `` vscode: 1.91.0 -> 1.91.1 ``                                                        |
| [`1daaa1f4`](https://github.com/NixOS/nixpkgs/commit/1daaa1f45d6f401ffa52e46b8332f66516c17003) | `` nss: 3.101.1 -> 3.101.2 ``                                                         |
| [`339d3915`](https://github.com/NixOS/nixpkgs/commit/339d39157cc73f8572e52dcd7458c556832aa5b3) | `` separateDebugInfo: tell rustc not to strip ``                                      |
| [`9352cc44`](https://github.com/NixOS/nixpkgs/commit/9352cc44be78d2932d45b5e2290421a279d930f5) | `` python312Packages.aiosmtpd: add some key reverse-dependencies to passthru.tests `` |
| [`7b530eab`](https://github.com/NixOS/nixpkgs/commit/7b530eabd8e890339cff9930a34c75823bf43223) | `` nss: 3.90.2 -> 3.101.1 ``                                                          |
| [`9a6422b8`](https://github.com/NixOS/nixpkgs/commit/9a6422b8b1e9ff61fd7d43c79b2f48fded586cc8) | `` python3Packages.aiosmtpd: 1.4.5 -> 1.4.6 ``                                        |
| [`99892b29`](https://github.com/NixOS/nixpkgs/commit/99892b299dcb3930c384f4eb74ae252ddb535d8a) | `` curl: fix CVE-2024-6197 ``                                                         |
| [`be87d438`](https://github.com/NixOS/nixpkgs/commit/be87d43800b9e20adf94ba7f296f1129b2c8ffde) | `` systemd: re-enable bpf-framework ``                                                |
| [`3789198f`](https://github.com/NixOS/nixpkgs/commit/3789198fb6ceaf0117ac74b511467c9c2d589b1d) | `` openrct2: 0.4.11 -> 0.4.12 ``                                                      |
| [`a10cd5b5`](https://github.com/NixOS/nixpkgs/commit/a10cd5b56dc4aef803abd420413be6503c26ce55) | `` orc: 0.4.38 -> 0.4.39 ``                                                           |
| [`c5e0ce35`](https://github.com/NixOS/nixpkgs/commit/c5e0ce359eb614169b2d37211ac0a4408feef048) | `` gtk3: 3.24.42 -> 3.24.43 ``                                                        |
| [`4a48f4cd`](https://github.com/NixOS/nixpkgs/commit/4a48f4cdf366720fe2ca837c0e29704d4b731d13) | `` systemd: 255.6 -> 255.9 ``                                                         |
| [`6e2d55ff`](https://github.com/NixOS/nixpkgs/commit/6e2d55ffcf0509509b59c3464ccbd31badfc72a6) | `` meson: 1.4.1 -> 1.4.2 ``                                                           |
| [`9558dddb`](https://github.com/NixOS/nixpkgs/commit/9558dddb3038e2e15daee902cf4c6d762e9f1436) | `` ruby_3_3: 3.3.3 -> 3.3.4 ``                                                        |
| [`5b3bb365`](https://github.com/NixOS/nixpkgs/commit/5b3bb3652b9a7680fa18a684e1aea97b06f31970) | `` haskellPackages: Pass ghc-options in generic-builder when cross-compiling ``       |