### PR TITLE
chore(flake/impermanence): `23c1f063` -> `c7f5b394`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1719091691,
-        "narHash": "sha256-AxaLX5cBEcGtE02PeGsfscSb/fWMnyS7zMWBXQWDKbE=",
+        "lastModified": 1724489415,
+        "narHash": "sha256-ey8vhwY/6XCKoh7fyTn3aIQs7WeYSYtLbYEG87VCzX4=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "23c1f06316b67cb5dabdfe2973da3785cfe9c34a",
+        "rev": "c7f5b394397398c023000cf843986ee2571a1fd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`03fe473c`](https://github.com/nix-community/impermanence/commit/03fe473c731cda2900bae9894b8dfc68e3492db5) | `` nixos: Formatting fixes ``                                                |
| [`785dd659`](https://github.com/nix-community/impermanence/commit/785dd6597b4fdc7f9f3b96a8f351be611ed56757) | `` nixos: Add option to toggle warnings ``                                   |
| [`467e24bd`](https://github.com/nix-community/impermanence/commit/467e24bd041e16a9752de7700d067b2efb9329c9) | `` nixos: Make the /var/lib/nixos assertion a warning and include parents `` |
| [`403d66ed`](https://github.com/nix-community/impermanence/commit/403d66ed8dcd350ba9af97f53fc636c5dc25ddeb) | `` removed obsolete word ``                                                  |
| [`213f8050`](https://github.com/nix-community/impermanence/commit/213f8050c9e9ddd8382224f962bf46f1ce5ac54f) | `` nixos: Add assertion for persisting UIDs/GIDs ``                          |