### PR TITLE
chore(flake/nix-ld-rs): `76a95ee3` -> `8af5fc9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -285,11 +285,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722802353,
-        "narHash": "sha256-bubBZ5JBs0unQp7aaepbXUsKC9USzpBdUJtFFuXTuvE=",
+        "lastModified": 1723871880,
+        "narHash": "sha256-HKHx2tDZEcKTKKkhyIDRifJW7a4bxOsWlvIVI1qm+ng=",
         "owner": "nix-community",
         "repo": "nix-ld-rs",
-        "rev": "76a95ee37d62495743d6e36cdf7f6076ed6adc64",
+        "rev": "8af5fc9add315c251edea8f659b56fc7836a163f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                    |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`8af5fc9a`](https://github.com/nix-community/nix-ld-rs/commit/8af5fc9add315c251edea8f659b56fc7836a163f) | `` README: deprecated this repository. ``                  |
| [`7e738a41`](https://github.com/nix-community/nix-ld-rs/commit/7e738a412f3fa41e1c2b80e4f784008bf11d3309) | `` fix(deps): update rust crate linux-raw-sys to v0.6.5 `` |
| [`6359e9fb`](https://github.com/nix-community/nix-ld-rs/commit/6359e9fb6e52e757b5f3d3bd05b741c3dd6c78f5) | `` chore(deps): update rust crate cc to v1.1.13 ``         |
| [`36feec0f`](https://github.com/nix-community/nix-ld-rs/commit/36feec0f10f8fa58b36ad0f27440984c116c83e3) | `` chore(deps): update rust crate cc to v1.1.12 ``         |
| [`ac50041a`](https://github.com/nix-community/nix-ld-rs/commit/ac50041a6f7581188b8a73ede86322e3340adc1f) | `` chore(deps): update rust crate cc to v1.1.11 ``         |
| [`d1b139e7`](https://github.com/nix-community/nix-ld-rs/commit/d1b139e7b8671ca1af26efaa71a28f3c031f9b66) | `` chore(deps): update rust crate cc to v1.1.10 ``         |
| [`c7317c78`](https://github.com/nix-community/nix-ld-rs/commit/c7317c78848785c5b7185b0bc1f67fbfd2507a95) | `` chore(deps): update rust crate cc to v1.1.9 ``          |
| [`4ce415e5`](https://github.com/nix-community/nix-ld-rs/commit/4ce415e564f9c606de91da58c391018e44166125) | `` chore(deps): update rust crate cc to v1.1.8 ``          |
| [`8e93390f`](https://github.com/nix-community/nix-ld-rs/commit/8e93390f68b5832a43fa3a03c796431fd6c5e5b8) | `` chore(deps): update rust crate tempfile to v3.12.0 ``   |