### PR TITLE
chore(flake/nixpkgs): `883180e6` -> `6e99f2a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -359,11 +359,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1722869614,
-        "narHash": "sha256-7ojM1KSk3mzutD7SkrdSflHXEujPvW1u7QuqWoTLXQU=",
+        "lastModified": 1725001927,
+        "narHash": "sha256-eV+63gK0Mp7ygCR0Oy4yIYSNcum2VQwnZamHxYTNi+M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "883180e6550c1723395a3a342f830bfc5c371f6b",
+        "rev": "6e99f2a27d600612004fbd2c3282d614bfee6421",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`6e99f2a2`](https://github.com/NixOS/nixpkgs/commit/6e99f2a27d600612004fbd2c3282d614bfee6421) | `` [Backport release-24.05] openvpn-auth-ldap: Fix CVE-2024-28820 (#338216) ``                  |
| [`3fed149a`](https://github.com/NixOS/nixpkgs/commit/3fed149ae547398f59fb895bad69e319fb1d9308) | `` linux_6_1: 6.1.106 -> 6.1.107 ``                                                             |
| [`1caf8bfb`](https://github.com/NixOS/nixpkgs/commit/1caf8bfb4d3b1c69f10a6fa7d67aafb54dc735e9) | `` linux_6_6: 6.6.47 -> 6.6.48 ``                                                               |
| [`c539074b`](https://github.com/NixOS/nixpkgs/commit/c539074b157914813b37bffddd1a0754c47ea201) | `` linux_6_10: 6.10.6 -> 6.10.7 ``                                                              |
| [`fa105073`](https://github.com/NixOS/nixpkgs/commit/fa105073ab2781053d3e86a49af85c3fe902aaae) | `` ungoogled-chromium: 128.0.6613.84-1 -> 128.0.6613.113-1 ``                                   |
| [`88940ce4`](https://github.com/NixOS/nixpkgs/commit/88940ce4f1c20b438e624b41bd09b4b030456873) | `` gsoap: fix cross compilation ``                                                              |
| [`009f9315`](https://github.com/NixOS/nixpkgs/commit/009f9315f9b34043bfb3a4a1f6a73d35a39120bb) | `` chromium,chromedriver: 128.0.6613.84 -> 128.0.6613.113 ``                                    |
| [`02e787ce`](https://github.com/NixOS/nixpkgs/commit/02e787cec806e8c0a7ec2c6002bd0a8f614cecf7) | `` thunderbirdPackages.thunderbird-115: 115.13.0 -> 115.14.0 ``                                 |
| [`8308f7dc`](https://github.com/NixOS/nixpkgs/commit/8308f7dce4f5bce0f650324d4ce8d5f24897996c) | `` signal-desktop: 7.21.0 -> 7.22.0, beta: 7.19.0-beta.1 -> 7.23.0-beta.1 ``                    |
| [`261db25a`](https://github.com/NixOS/nixpkgs/commit/261db25a2d554b915ec107b0161b9467de1d675c) | `` teams-for-linux: 1.4.27 -> 1.9.5 ``                                                          |
| [`889ce5b2`](https://github.com/NixOS/nixpkgs/commit/889ce5b2c82e72ab1d720076295a343fa345d3dc) | `` teams-for-linux: add khaneliman maintainer ``                                                |
| [`1075a62a`](https://github.com/NixOS/nixpkgs/commit/1075a62a0356802d3bfd39d5165fb578de1846d4) | `` teams-for-linux: move to by-name ``                                                          |
| [`40d73c78`](https://github.com/NixOS/nixpkgs/commit/40d73c784cb38c94da6f5324fe83a69168aeaa66) | `` teams-for-linux: fmt ``                                                                      |
| [`3fda3e13`](https://github.com/NixOS/nixpkgs/commit/3fda3e130ecdae87bfb2b2e0ee7a9e6a3c1f5b6e) | `` bitwarden-desktop: ensure no unfree source is used ``                                        |
| [`71132380`](https://github.com/NixOS/nixpkgs/commit/7113238008da1815b9b5c7193f4164ea5d392487) | `` bitwarden-desktop: 2024.8.0 -> 2024.8.1 ``                                                   |
| [`9d0e4143`](https://github.com/NixOS/nixpkgs/commit/9d0e41430ac6daa89cf07d4cc4cf0763c29d8b5d) | `` kanidm: require big-parallel for building ``                                                 |
| [`3066eafe`](https://github.com/NixOS/nixpkgs/commit/3066eafe80edff1e5e07de48dc33147b6344f73a) | `` canon-cups-ufr2: 5.70 -> 5.90 ``                                                             |
| [`d9cb5180`](https://github.com/NixOS/nixpkgs/commit/d9cb51800cd03bbf85c8e31f840d242f108c7a92) | `` uwsm: 0.18.0 -> 0.18.2 ``                                                                    |
| [`98b25eb0`](https://github.com/NixOS/nixpkgs/commit/98b25eb0c7be0ea06aed734aeed3642316037220) | `` uwsm: 0.17.4 -> 0.18.0 ``                                                                    |
| [`bb9ef197`](https://github.com/NixOS/nixpkgs/commit/bb9ef197f3409a352b9f6f91759b40096ca7705c) | `` uwsm: 0.17.2 -> 0.17.4 ``                                                                    |
| [`444d1181`](https://github.com/NixOS/nixpkgs/commit/444d11818a3af6191d2a17bec33471438e51b1e6) | `` uwsm: also wrap sway and hyprland's paths ``                                                 |
| [`bf54a4c4`](https://github.com/NixOS/nixpkgs/commit/bf54a4c45a2ab5d0aec01641969acf9998e9d09c) | `` uwsm: fix dependencies add wrap the binary as well ``                                        |
| [`12d6d4cf`](https://github.com/NixOS/nixpkgs/commit/12d6d4cf38e22d885410c436be97a1f096d68eb5) | `` uwsm: 0.17.0 -> 0.17.2 ``                                                                    |
| [`0ec42ae1`](https://github.com/NixOS/nixpkgs/commit/0ec42ae1d58e76f463b6510706a33b1c785470ff) | `` uwsm: add kai-tub to maintainers ``                                                          |
| [`5a1c3f55`](https://github.com/NixOS/nixpkgs/commit/5a1c3f5557ddfc7eee8ba5c75f7063c76db6564b) | `` feishin: use electron_31 ``                                                                  |
| [`21a75e09`](https://github.com/NixOS/nixpkgs/commit/21a75e0916edc7268ac0b7aad178a800304e4ab1) | `` feishin: change `${pname}` to string literal ``                                              |
| [`3a204ea6`](https://github.com/NixOS/nixpkgs/commit/3a204ea666b29ba2215f911825299c8997554a60) | `` feishin: upgrade electron to v30 ``                                                          |
| [`f802ba42`](https://github.com/NixOS/nixpkgs/commit/f802ba42413aaf90d0b87821e39c20fbbfcbff68) | `` lx-music-desktop: 2.8.0 -> 2.9.0 ``                                                          |
| [`3f2a98cf`](https://github.com/NixOS/nixpkgs/commit/3f2a98cf4bf267fe86553712ae46a3b20d2ce321) | `` electron-source.electron_29: remove as it's EOL ``                                           |
| [`35f64ff5`](https://github.com/NixOS/nixpkgs/commit/35f64ff5b864b8bac6717044f423a37f54f02998) | `` electron_29-bin: mark as insecure because it's EOL ``                                        |
| [`7ec0f645`](https://github.com/NixOS/nixpkgs/commit/7ec0f64595a06e3e28b2fc42c3fe4aeba67aa2dd) | `` electron-chromedriver_30: 30.3.1 -> 30.4.0 ``                                                |
| [`fc3ced2a`](https://github.com/NixOS/nixpkgs/commit/fc3ced2a81a2dfbe3a968c142deb8735161b3f51) | `` electron-chromedriver_29: 29.4.5 -> 29.4.6 ``                                                |
| [`dd14c65b`](https://github.com/NixOS/nixpkgs/commit/dd14c65b45ce38bd5ed6e6cfa2fa3a3b81ff86b9) | `` electron-source.electron_30: 30.3.1 -> 30.4.0 ``                                             |
| [`0a3e926a`](https://github.com/NixOS/nixpkgs/commit/0a3e926ad3ab751b19b8c4bc021ac0915554f90e) | `` electron-source.electron_29: 29.4.5 -> 29.4.6 ``                                             |
| [`00837607`](https://github.com/NixOS/nixpkgs/commit/0083760702e7212c1f4342ba247e1c8b3a461971) | `` electron_30-bin: 30.3.1 -> 30.4.0 ``                                                         |
| [`c08e34ab`](https://github.com/NixOS/nixpkgs/commit/c08e34aba1627c6332e68c1c652de324bbdd5bdc) | `` electron_29-bin: 29.4.5 -> 29.4.6 ``                                                         |
| [`953a5b7c`](https://github.com/NixOS/nixpkgs/commit/953a5b7cdc8b83a0a176c11cbc3bb43f678542d7) | `` chromium,electron-source: remove no longer needed version conditionals ``                    |
| [`9cf01721`](https://github.com/NixOS/nixpkgs/commit/9cf01721658ad0dbfac6014ef1420ca9c64b3dda) | `` koboldcpp: 1.73 -> 1.73.1 ``                                                                 |
| [`a228cccb`](https://github.com/NixOS/nixpkgs/commit/a228cccb762a5163b7aaaff335dadfddfd985f45) | `` koboldcpp: sort meta and add changelog ``                                                    |
| [`15a2bb6d`](https://github.com/NixOS/nixpkgs/commit/15a2bb6d13896304598c87f99a392f3cee093807) | `` koboldcpp: 1.72 -> 1.73 ``                                                                   |
| [`a58b3c58`](https://github.com/NixOS/nixpkgs/commit/a58b3c5834f9d86e75c3cdc938070d153c5c9046) | `` departure-mono: init at 1.346 ``                                                             |
| [`a4476dd7`](https://github.com/NixOS/nixpkgs/commit/a4476dd728544bffba6b03458754ebad01d1cf1d) | `` grafana: 10.4.7 -> 10.4.8 ``                                                                 |
| [`0019eff7`](https://github.com/NixOS/nixpkgs/commit/0019eff7c5ea861189670aa650b37dcdb8b63a10) | `` lx-music-desktop: 2.7.0 -> 2.8.0 ``                                                          |
| [`738281b6`](https://github.com/NixOS/nixpkgs/commit/738281b62d805eb26dcd3aae023103b3975ea82e) | `` powerpipe: 0.4.2 -> 0.4.3 ``                                                                 |
| [`6a7538a6`](https://github.com/NixOS/nixpkgs/commit/6a7538a660994c6e644f56e2418cfcc0b704277e) | `` webtorrent_desktop: update and use latest electron (#320293) ``                              |
| [`7e2c6684`](https://github.com/NixOS/nixpkgs/commit/7e2c6684ba59d65a85cd58ecd4799949818ffb3d) | `` webtorrent_desktop: make fetchpatch url reproducible ``                                      |
| [`8e4470a7`](https://github.com/NixOS/nixpkgs/commit/8e4470a74283aceb42d679947bc4340e693b1f74) | `` obsidian: remove reduant inherit ``                                                          |
| [`8992b4b4`](https://github.com/NixOS/nixpkgs/commit/8992b4b4573f299ed1f66792e43923ce6877f04f) | `` obsidian: add meta.mainProgram ``                                                            |
| [`831e08a8`](https://github.com/NixOS/nixpkgs/commit/831e08a898293513bcba2a95e620579300ed6ef3) | `` obsidian: 1.6.5 -> 1.6.7 ``                                                                  |
| [`2e18df30`](https://github.com/NixOS/nixpkgs/commit/2e18df30b60a012e511912ef3ce3f7450b2e2ca2) | `` obsidian: 1.6.3 -> 1.6.5 ``                                                                  |
| [`17416ac0`](https://github.com/NixOS/nixpkgs/commit/17416ac0efd8f6b9458b0a5d6a1bb5f421cc0489) | `` obsidian: add commandLineArgs ``                                                             |
| [`42f8839e`](https://github.com/NixOS/nixpkgs/commit/42f8839e0ecbba9ee64dd939ebc0e3d9d569fee7) | `` obsidian: removed electron version pin ``                                                    |
| [`871312f8`](https://github.com/NixOS/nixpkgs/commit/871312f892be7c2fe513ebb1da198b4c8f8501d7) | `` obsidian: update hash ``                                                                     |
| [`37177b61`](https://github.com/NixOS/nixpkgs/commit/37177b6182f400e44ce8c15b34640a37a5d2cad2) | `` obsidian: 1.5.12 -> 1.6.3 ``                                                                 |
| [`f7d1c7b9`](https://github.com/NixOS/nixpkgs/commit/f7d1c7b9f2448716e8fa5349cf50acae7b529db3) | `` feishin: 0.7.1 -> 0.7.3 ``                                                                   |
| [`1a11e462`](https://github.com/NixOS/nixpkgs/commit/1a11e462c1f3fe511e00da7fe04dd9461c5ac384) | `` feishin: move to pkgs/by-name ``                                                             |
| [`8fbcdbc6`](https://github.com/NixOS/nixpkgs/commit/8fbcdbc68dbd2f6974f7142ec4184fe4841e59c8) | `` ride: add patch to support later electron versions ``                                        |
| [`b2a845d7`](https://github.com/NixOS/nixpkgs/commit/b2a845d7eeb122aeb75e1dc6e28b17b1bc7ab7b0) | `` blockbench: remove electron version pin ``                                                   |
| [`6d175be5`](https://github.com/NixOS/nixpkgs/commit/6d175be58f6b3bc03c221c07e038f43c13c13fe9) | `` electron-source.electron_{27,28}: remove instead of marking them as EOL ``                   |
| [`3ed9728d`](https://github.com/NixOS/nixpkgs/commit/3ed9728d5cf3717daf1c57a412e1bd191be8977a) | `` electron*: mark older versions as EOL ``                                                     |
| [`3854dde4`](https://github.com/NixOS/nixpkgs/commit/3854dde46568dd58c0b42aa6e28912e37401bdd6) | `` antares: 0.7.24 -> 0.7.28 ``                                                                 |
| [`1a42560e`](https://github.com/NixOS/nixpkgs/commit/1a42560e0d113dbdafac67fe36ee48aaa833809a) | `` yarn2nix: remove GPLv3 licence ``                                                            |
| [`361c1e5c`](https://github.com/NixOS/nixpkgs/commit/361c1e5c2aa6cf3c5e2c34b245c3f7623921f461) | `` eris-go: 20240128 -> 20240826 ``                                                             |
| [`665a1853`](https://github.com/NixOS/nixpkgs/commit/665a1853b5523c35872ccc16054c6f2484a19e15) | `` nixos/eris-server: update comment ``                                                         |
| [`a4eae086`](https://github.com/NixOS/nixpkgs/commit/a4eae08694c9c88773d3d2c9a7e11bb9f1f43dad) | `` hydra_unstable: Fix CVE-2024-45049 ``                                                        |
| [`f44a0b4e`](https://github.com/NixOS/nixpkgs/commit/f44a0b4e110e512a3d796e5749cbe67cdb01fd57) | `` picosnitch: mark as vulnerable ``                                                            |
| [`691e0952`](https://github.com/NixOS/nixpkgs/commit/691e09524a7c798040225c6c93812e1fa6ceabfa) | `` nixos/varnish: change default stateDir to /run ``                                            |
| [`ce076366`](https://github.com/NixOS/nixpkgs/commit/ce0763669f527f5984a590f416964872403787d9) | `` knot-dns: 3.3.8 -> 3.3.9 ``                                                                  |
| [`404584d5`](https://github.com/NixOS/nixpkgs/commit/404584d54d5d1179b1a24627ffd1b5edbbcdb2a7) | `` thunderbird-unwrapped: 128.1.0esr -> 128.1.1esr ``                                           |
| [`c4205633`](https://github.com/NixOS/nixpkgs/commit/c4205633715ec541d62a55f36345e93fe5e48187) | `` signal-desktop: replace unlicensed Apple emoji ``                                            |
| [`2e7721ba`](https://github.com/NixOS/nixpkgs/commit/2e7721ba4d887893e7c6f958a419aaf76039f803) | `` signal-desktop: add myself to maintainers ``                                                 |
| [`08e5e55c`](https://github.com/NixOS/nixpkgs/commit/08e5e55c2a2e27e43ee3dab85828a3dac87ad705) | `` pretix: apply patch for CVE-2024-8113 ``                                                     |
| [`3e9a1b6c`](https://github.com/NixOS/nixpkgs/commit/3e9a1b6cafe678190a8509586027a3316b6812df) | `` maintainers: remove superherointj ``                                                         |
| [`528398da`](https://github.com/NixOS/nixpkgs/commit/528398da643ebc0695264f32853c4b96a05a7091) | `` netbird: 0.28.8 -> 0.28.9 ``                                                                 |
| [`29e54dda`](https://github.com/NixOS/nixpkgs/commit/29e54dda68d2807998c86365f65f5eba0c3a46c8) | `` maintainer: add vrifox ``                                                                    |
| [`49cc3841`](https://github.com/NixOS/nixpkgs/commit/49cc3841743a92d9af27e65d6a2fb094c7864581) | `` Kernel: update testing to 6.11-rc5 ``                                                        |
| [`ed6ca3c6`](https://github.com/NixOS/nixpkgs/commit/ed6ca3c6a89fc385ca4eebbcd397bd9015945b18) | `` forgejo-runner: 3.5.0 -> 3.5.1 ``                                                            |
| [`7c7a8c1a`](https://github.com/NixOS/nixpkgs/commit/7c7a8c1aeeefba20dbba70c4e5bb2a35c8f922b0) | `` forgejo-runner: 3.4.1 -> 3.5.0 ``                                                            |
| [`9608b32d`](https://github.com/NixOS/nixpkgs/commit/9608b32d810189b92a8d9878505264bcfd3fdc5d) | `` Discord updates ``                                                                           |
| [`3f6b5336`](https://github.com/NixOS/nixpkgs/commit/3f6b5336eb20bfbfad0943d8ca40bbcb86e78b10) | `` discord: 0.0.63 -> 0.0.64 ``                                                                 |
| [`e4066581`](https://github.com/NixOS/nixpkgs/commit/e4066581c7245ce574c43f1afc6702d868c42923) | `` simplex-chat-desktop: 5.8.1 -> 6.0.3 ``                                                      |
| [`b67636a4`](https://github.com/NixOS/nixpkgs/commit/b67636a4b13b835861180e69c71a3b2600b17fce) | `` flyctl: 0.2.114 -> 0.2.120 ``                                                                |
| [`53a72b6f`](https://github.com/NixOS/nixpkgs/commit/53a72b6f7d2262085d9dc05b25a12964884c6a59) | `` adwaita-icon-theme-legacy: init at 46.2 ``                                                   |
| [`fdd1865a`](https://github.com/NixOS/nixpkgs/commit/fdd1865a4853bcc5f713bb0fe9c34ac5a682e386) | `` morgen: electron_29 -> electron_30 ``                                                        |
| [`1620cf62`](https://github.com/NixOS/nixpkgs/commit/1620cf62264da436a4d527662b1f209004031f2d) | `` morgen: 3.5.1 -> 3.5.5 ``                                                                    |
| [`04113f1c`](https://github.com/NixOS/nixpkgs/commit/04113f1cde36c2ee1218b688eb920ddc28713bb0) | `` morgen: 3.4.5 -> 3.5.1 ``                                                                    |
| [`f99b0ce1`](https://github.com/NixOS/nixpkgs/commit/f99b0ce108efc10e47dc729237b4e3247371dd79) | `` morgen: 3.4.4 -> 3.4.5 ``                                                                    |
| [`ed32d0ab`](https://github.com/NixOS/nixpkgs/commit/ed32d0ab100308107975288533eb42c818a1bbe3) | `` morgen: electron_28 -> electron_29 ``                                                        |
| [`4cefad5a`](https://github.com/NixOS/nixpkgs/commit/4cefad5a46f18256953b885dfa982c559e36fc69) | `` morgen: 3.4.3 -> 3.4.4 ``                                                                    |
| [`1bae4c84`](https://github.com/NixOS/nixpkgs/commit/1bae4c84ee430f046d55453cb4c84486bade05fd) | `` morgen: 3.4.2 -> 3.4.3 ``                                                                    |
| [`81a75e9d`](https://github.com/NixOS/nixpkgs/commit/81a75e9d2ff3ff519efe69b931d6e8f1ddd0fa76) | `` gitlab: 17.2.2 -> 17.2.4 ``                                                                  |
| [`8e13b43d`](https://github.com/NixOS/nixpkgs/commit/8e13b43d94e2d41c5dd463e1d05e4ce2ef341093) | `` perlPackages.DBI: 1.643 -> 1.644 ``                                                          |
| [`5fda26f9`](https://github.com/NixOS/nixpkgs/commit/5fda26f950a00bb87e910aff03e6e4e1859d75a4) | `` deploy-rs: unstable-2024-02-16 -> 0-unstable-2024-06-12 ``                                   |
| [`fb3ed602`](https://github.com/NixOS/nixpkgs/commit/fb3ed6024c63cfb46de99baa23ecad230b5a74da) | `` deploy-rs: move to by-name ``                                                                |
| [`0892020c`](https://github.com/NixOS/nixpkgs/commit/0892020c56829e4fe511e338ef13ef0d21173ba6) | `` i2p: 2.5.1 -> 2.6.1 ``                                                                       |
| [`d5d2de09`](https://github.com/NixOS/nixpkgs/commit/d5d2de09313bed25683535645674b1d413c36981) | `` librewolf: 129.0.1-1 -> 129.0.2-1 ``                                                         |
| [`7d99e53b`](https://github.com/NixOS/nixpkgs/commit/7d99e53b65b4305632ba97670daa540f2019c3eb) | `` imagemagick: 7.1.1-36 -> 7.1.1-37 ``                                                         |
| [`83069d01`](https://github.com/NixOS/nixpkgs/commit/83069d01a613b11996729524a64ae4b89ea24cfe) | `` pnpm_9: 9.6.0 -> 9.7.0 ``                                                                    |
| [`1376fa54`](https://github.com/NixOS/nixpkgs/commit/1376fa54c2a6e02c99cf4f6da874fd1495d63ba8) | `` pnpm.fetchDeps: Add workspaces support and support for custom pnpm configuration commands `` |
| [`10481a20`](https://github.com/NixOS/nixpkgs/commit/10481a20563730c6d62838e1fdf66eb757185d06) | `` pnpm_{8,9}.fetchDeps: fix --ignore-scripts argument ``                                       |
| [`39d4d862`](https://github.com/NixOS/nixpkgs/commit/39d4d862a25544dd484120ac4849c9269aab7b1b) | `` pnpm_{8,9}.fetchDeps: put all pnpm install arguments in separate lines ``                    |
| [`5e5f785f`](https://github.com/NixOS/nixpkgs/commit/5e5f785fa9aaad68ecc1bfa316e1bfa49daa48b4) | `` pnpm_8: 8.15.8 -> 8.15.9 ``                                                                  |
| [`72b6b2e8`](https://github.com/NixOS/nixpkgs/commit/72b6b2e8f5977bb147ba47c009f6729eaa50874a) | `` pnpm_9: 9.4.0 -> 9.6.0 ``                                                                    |
| [`1e7d78a5`](https://github.com/NixOS/nixpkgs/commit/1e7d78a522ed72773d49ad26b4f64fb32b699ac5) | `` pnpm_9: 9.3.0 -> 9.4.0 ``                                                                    |
| [`0c8b42a5`](https://github.com/NixOS/nixpkgs/commit/0c8b42a51a8b7e5cef361fc7aa948f0002da4682) | `` pnpm.fetchDeps: error if lockfile version has a mismatch ``                                  |
| [`eb5d55b2`](https://github.com/NixOS/nixpkgs/commit/eb5d55b2af160665e5f5fe5381a2e14bc8ec09ee) | `` pnpm.fetchDeps: misc cleanup ``                                                              |
| [`7a627e33`](https://github.com/NixOS/nixpkgs/commit/7a627e3337f9e286af274b69d3b7cc84ebc7d4bd) | `` pnpm: install shell completions ``                                                           |
| [`1f011f99`](https://github.com/NixOS/nixpkgs/commit/1f011f99a6d61de0d17c725808666f90df310445) | `` pnpm: 9.1.1 -> 9.3.0 ``                                                                      |
| [`026b7704`](https://github.com/NixOS/nixpkgs/commit/026b770445fcb4b7de5d13b04d437830f441d8fe) | `` doc/javascript: pnpm: mention lack of monorepos/workspaces support ``                        |
| [`b05ae8fa`](https://github.com/NixOS/nixpkgs/commit/b05ae8faade5592fea2894f2a3395ac2217e107f) | `` pnpm_{8,9}: remove uneeded binary files from src ``                                          |
| [`b4f5b3fa`](https://github.com/NixOS/nixpkgs/commit/b4f5b3fa1a7dacceb2efc92ed42eeaf2971a7773) | `` pnpm.fetchDeps: add serve script ``                                                          |
| [`3f4a4d06`](https://github.com/NixOS/nixpkgs/commit/3f4a4d0672c4f5f0787f53b086a15be0067de88b) | `` pnpm.fetchDeps: init ``                                                                      |
| [`8fe4a3a9`](https://github.com/NixOS/nixpkgs/commit/8fe4a3a933fee677d79e5623b784df43194662d4) | `` pnpm: init at 9.1.1 ``                                                                       |
| [`57321d2e`](https://github.com/NixOS/nixpkgs/commit/57321d2ed2f5bbe6bfc32f23a2d219db1eef84a5) | `` nodePackages: enable overriding src and name attrs ``                                        |
| [`3226e7cd`](https://github.com/NixOS/nixpkgs/commit/3226e7cd5306ffa1903edd235460fa8680aa8c12) | `` librewolf-unwrapped: use settings from submodule ``                                          |
| [`bf04bfe6`](https://github.com/NixOS/nixpkgs/commit/bf04bfe620c2e99dab8d4c1755e96e077fe2368d) | `` bitwarden-desktop: 2024.6.4 -> 2024.8.0 ``                                                   |
| [`c5291d37`](https://github.com/NixOS/nixpkgs/commit/c5291d371009a4549f0fa9ae90af0c342c969cf3) | `` comet-gog: 0-unstable-2024-05-25 -> 0.1.2 ``                                                 |
| [`a511d56c`](https://github.com/NixOS/nixpkgs/commit/a511d56c97d07d0a97e7fbef4f1fc57537673a9a) | `` comet-gog: init at 0-unstable-2024-05-25 ``                                                  |
| [`3f59c6a2`](https://github.com/NixOS/nixpkgs/commit/3f59c6a2e8c5999678b75f6a3dcc01f624c1c28d) | `` heroic: 2.14.1 -> 2.15.1 ``                                                                  |
| [`2437b36c`](https://github.com/NixOS/nixpkgs/commit/2437b36cdac87e85a1a4e20b04325c8d32ccd11b) | `` heroic: add icu to FHS env ``                                                                |
| [`1bf3945c`](https://github.com/NixOS/nixpkgs/commit/1bf3945cd47ea17526e7e359758c84fdbb9499ef) | `` webcord-vencord: electron_29 -> electron_30 ``                                               |
| [`2d7eef9f`](https://github.com/NixOS/nixpkgs/commit/2d7eef9fd7b152983f78c7669a16b0d46b210f70) | `` perlPackages.Appcpanminus: fix https hotpatch ``                                             |
| [`c7944362`](https://github.com/NixOS/nixpkgs/commit/c79443628569340d9f3e843e1b4581ad4924d36c) | `` nixos/tests/firewall: fix deprecation warning ``                                             |
| [`749b4b36`](https://github.com/NixOS/nixpkgs/commit/749b4b36d4e0559bd1458c50f62ced68df76ceed) | `` nixos/firewall: fix reverse path check failures with IPsec ``                                |
| [`2c8f6aa7`](https://github.com/NixOS/nixpkgs/commit/2c8f6aa77d72bb8f1d666ffc574c5147627766b7) | `` librewolf-unwrapped: add librewolf pref pane ``                                              |
| [`8e67536f`](https://github.com/NixOS/nixpkgs/commit/8e67536f766ec87dcc50e8c48b9deb27690606b0) | `` python311Packages.wagtail: 6.0.5 -> 6.0.6 ``                                                 |
| [`1ded7e15`](https://github.com/NixOS/nixpkgs/commit/1ded7e150fe5cad3dc13581b6f48efd2e8c27ef0) | `` suricata: 7.0.5 -> 7.0.6 ``                                                                  |
| [`49a67953`](https://github.com/NixOS/nixpkgs/commit/49a67953e47d846cb8f6566611cd3eaeff5e9c9c) | `` librewolf-unwrapped: 129.0.1 -> 129.0.1-1 ``                                                 |
| [`a96391a3`](https://github.com/NixOS/nixpkgs/commit/a96391a3faea2b68423cf7988a091ddd62ff87ef) | `` librewolf-unwrapped: use nvidia wayland vendored patches, format using nixfmt-rfc-style ``   |
| [`0703a286`](https://github.com/NixOS/nixpkgs/commit/0703a286aede7c555b3f51e5eae5aca4e35d9d68) | `` mautrix-meta: 0.3.1 -> 0.3.2 ``                                                              |
| [`b60e13a1`](https://github.com/NixOS/nixpkgs/commit/b60e13a1d5b33b7d1c492ac443e51575337cebc8) | `` signal-desktop: 7.19.0 -> 7.21.0 ``                                                          |
| [`3d512e18`](https://github.com/NixOS/nixpkgs/commit/3d512e1832b1bce1006ada313596f2352472af1f) | `` fastly: 10.13.1 -> 10.13.3 ``                                                                |
| [`53d5d2be`](https://github.com/NixOS/nixpkgs/commit/53d5d2be6da58a50807997f42ececd8145358513) | `` nixos/ups: restart upsdrv.service on config changes ``                                       |
| [`1ace5f2e`](https://github.com/NixOS/nixpkgs/commit/1ace5f2e7aa2f1d2ceaf8bb4e00f58f9cf28c895) | `` ungoogled-chromium: 127.0.6533.119-2 -> 128.0.6613.84-1 ``                                   |
| [`3fda748f`](https://github.com/NixOS/nixpkgs/commit/3fda748f5470c408234629d94dd53e622ad7d838) | `` chromium,chromedriver: 127.0.6533.119 -> 128.0.6613.84 ``                                    |
| [`e40e5d08`](https://github.com/NixOS/nixpkgs/commit/e40e5d0871d258c4e9c1322f91e54640157fda09) | `` buildkite-agent: 3.76.2 -> 3.77.0 ``                                                         |
| [`5db23275`](https://github.com/NixOS/nixpkgs/commit/5db2327502d220e815be6ca48099266684160d31) | `` buildkite-agent: 3.76.1 -> 3.76.2 ``                                                         |
| [`e6a019c9`](https://github.com/NixOS/nixpkgs/commit/e6a019c9140d4893858365e99494dd0e1a5974d1) | `` buildkite-agent: 3.59.0 -> 3.76.1 ``                                                         |
| [`e3fa245e`](https://github.com/NixOS/nixpkgs/commit/e3fa245e259b627523ebe1f5ebd94e7f7aafec54) | `` buildkite-agent: move to by-name ``                                                          |
| [`d10675c4`](https://github.com/NixOS/nixpkgs/commit/d10675c43128b3d0d18f231828aa941c2ac34c3b) | `` nextcloudPackages: update ``                                                                 |
| [`a011d863`](https://github.com/NixOS/nixpkgs/commit/a011d8634e76c61808a10920bf48b291fe783a0f) | `` nextcloud29: 29.0.4 -> 29.0.5 ``                                                             |
| [`9465c61b`](https://github.com/NixOS/nixpkgs/commit/9465c61bb2ebc53841389cb5f413968773ab1c63) | `` nextcloud28: 28.0.8 -> 28.0.9 ``                                                             |
| [`0f74c87e`](https://github.com/NixOS/nixpkgs/commit/0f74c87e84d640e26bdb15454ca210e3147c9f98) | `` meshcentral: 1.1.26 -> 1.1.27 ``                                                             |
| [`3e945553`](https://github.com/NixOS/nixpkgs/commit/3e9455537d4ef02b13b2380ea73426a9efedfd94) | `` nix-perl: fix build for 2.24 ``                                                              |
| [`59bc7ee1`](https://github.com/NixOS/nixpkgs/commit/59bc7ee12b70acaa9bd5aa3be31d8dce2b53e9bc) | `` google-chrome: 127.0.6533.119 -> 128.0.6613.84/128.0.6613.85 ``                              |
| [`aaaf6cc6`](https://github.com/NixOS/nixpkgs/commit/aaaf6cc690d70d75fde12dc5960f2059fabfd20b) | `` nut: enable the GPIO driver ``                                                               |
| [`5b3f2818`](https://github.com/NixOS/nixpkgs/commit/5b3f28182729fd79c9365e84a1576a582259b039) | `` nut: 2.8.0 -> 2.8.2 ``                                                                       |
| [`96c742c7`](https://github.com/NixOS/nixpkgs/commit/96c742c78f5a2a47d72252eeb5634a093e7c2ab8) | `` kanidm: lower rust requrement to 1.77 ``                                                     |
| [`ec4dd6d7`](https://github.com/NixOS/nixpkgs/commit/ec4dd6d792601e092d383d7f6e177c9a17239ac6) | `` tests/lomiri-camera-app: Fix backported test ``                                              |
| [`669d0c9d`](https://github.com/NixOS/nixpkgs/commit/669d0c9dea216f3a37d289ff4174abdead850b7c) | `` nixos/lomiri: Add gallery app ``                                                             |
| [`d8667755`](https://github.com/NixOS/nixpkgs/commit/d86677556f87e20dc84f2f12647c242db808ae97) | `` tests/lomiri-gallery-app: init ``                                                            |
| [`60ac12a4`](https://github.com/NixOS/nixpkgs/commit/60ac12a4f89e8488f4f60bd851a94369042a5658) | `` lomiri.lomiri-gallery-app: init at 3.0.2 ``                                                  |
| [`00abdbc6`](https://github.com/NixOS/nixpkgs/commit/00abdbc62033e9717a69f453e18ece8ee8b83d3a) | `` nixos/tests/kanidm: bind certs path to fix ofborg tests ``                                   |
| [`799b4451`](https://github.com/NixOS/nixpkgs/commit/799b4451fdd532610786f8b81b642767de3253c4) | `` lib.systems: throw if `sdkVer` or `ndkVer` are used for android. ``                          |
| [`f10dac3c`](https://github.com/NixOS/nixpkgs/commit/f10dac3c89a311343f41b42c917e562e382e68fc) | `` kanidm: 1.3.2 -> 1.3.3 ``                                                                    |
| [`33afc30f`](https://github.com/NixOS/nixpkgs/commit/33afc30f272133683f5211a3c5910d0a304ad24f) | `` kanidm: pin updatescript to version tags ``                                                  |
| [`b6e813b8`](https://github.com/NixOS/nixpkgs/commit/b6e813b8cdd7bbf4f447ec4c259c85155a5cf06f) | `` treewide: Rename android `sdkVer` and `ndkVer` ``                                            |
| [`70694011`](https://github.com/NixOS/nixpkgs/commit/706940115d5312516b8ef24772f136e3c7d70ea1) | `` kanidm: 1.3.1 -> 1.3.2 ``                                                                    |
| [`13b70069`](https://github.com/NixOS/nixpkgs/commit/13b70069b757b5da7e3fb48e20e9095e8fa8bb26) | `` kanidm: 1.2.3 -> 1.3.1 ``                                                                    |
| [`213edbbc`](https://github.com/NixOS/nixpkgs/commit/213edbbcfed0ec4dd671736c044e92e7dee82ac5) | `` [nixos-24.05] zed-editor: remove package ``                                                  |
| [`583b0b0c`](https://github.com/NixOS/nixpkgs/commit/583b0b0c1c5563a58166c43bf26f683e324bfa09) | `` floorp: align build options with upstream ``                                                 |
| [`04830225`](https://github.com/NixOS/nixpkgs/commit/0483022561b5bd3235a791626c34ae1616cebe03) | `` floorp: 11.16.0 -> 11.17.5 ``                                                                |